### PR TITLE
ensure entities referenced by @inline(__always) functions are versioned

### DIFF
--- a/Sources/Atomics/atomics-bool.swift
+++ b/Sources/Atomics/atomics-bool.swift
@@ -10,7 +10,7 @@ import ClangAtomics
 
 public struct AtomicBool
 {
-  fileprivate var val = Atomic32()
+  @_versioned internal var val = Atomic32()
   public init(_ value: Bool = false)
   {
     Store32(value ? 1 : 0, &val, memory_order_relaxed)

--- a/Sources/Atomics/atomics-integer.swift
+++ b/Sources/Atomics/atomics-integer.swift
@@ -12,7 +12,7 @@ import ClangAtomics
 
 public struct AtomicInt
 {
-  fileprivate var val = AtomicWord()
+  @_versioned internal var val = AtomicWord()
   public init(_ value: Int = 0)
   {
     StoreWord(value, &val, memory_order_relaxed)
@@ -104,7 +104,7 @@ extension AtomicInt
 
 public struct AtomicUInt
 {
-  fileprivate var val = AtomicWord()
+  @_versioned internal var val = AtomicWord()
   public init(_ value: UInt = 0)
   {
     StoreWord(unsafeBitCast(value, to: Int.self), &val, memory_order_relaxed)
@@ -198,7 +198,7 @@ extension AtomicUInt
 
 public struct AtomicInt32
 {
-  fileprivate var val = Atomic32()
+  @_versioned internal var val = Atomic32()
   public init(_ value: Int32 = 0)
   {
     Store32(value, &val, memory_order_relaxed)
@@ -290,7 +290,7 @@ extension AtomicInt32
 
 public struct AtomicUInt32
 {
-  fileprivate var val = Atomic32()
+  @_versioned internal var val = Atomic32()
   public init(_ value: UInt32 = 0)
   {
     Store32(unsafeBitCast(value, to: Int32.self), &val, memory_order_relaxed)
@@ -384,7 +384,7 @@ extension AtomicUInt32
 
 public struct AtomicInt64
 {
-  fileprivate var val = Atomic64()
+  @_versioned internal var val = Atomic64()
   public init(_ value: Int64 = 0)
   {
     Store64(value, &val, memory_order_relaxed)
@@ -476,7 +476,7 @@ extension AtomicInt64
 
 public struct AtomicUInt64
 {
-  fileprivate var val = Atomic64()
+  @_versioned internal var val = Atomic64()
   public init(_ value: UInt64 = 0)
   {
     Store64(unsafeBitCast(value, to: Int64.self), &val, memory_order_relaxed)

--- a/Sources/Atomics/atomics-pointer.swift
+++ b/Sources/Atomics/atomics-pointer.swift
@@ -11,7 +11,7 @@ import ClangAtomics
 
 public struct AtomicMutableRawPointer
 {
-  fileprivate var ptr = RawPointer()
+  @_versioned internal var ptr = RawPointer()
   public init(_ pointer: UnsafeMutableRawPointer? = nil)
   {
     StoreRawPtr(pointer, &ptr, memory_order_relaxed)
@@ -63,7 +63,7 @@ extension AtomicMutableRawPointer
 
 public struct AtomicRawPointer
 {
-  fileprivate var ptr = RawPointer()
+  @_versioned internal var ptr = RawPointer()
   public init(_ pointer: UnsafeRawPointer? = nil)
   {
     StoreRawPtr(pointer, &ptr, memory_order_relaxed)
@@ -115,7 +115,7 @@ extension AtomicRawPointer
 
 public struct AtomicMutablePointer<Pointee>
 {
-  fileprivate var ptr = RawPointer()
+  @_versioned internal var ptr = RawPointer()
   public init(_ pointer: UnsafeMutablePointer<Pointee>? = nil)
   {
     StoreRawPtr(pointer, &ptr, memory_order_relaxed)
@@ -167,7 +167,7 @@ extension AtomicMutablePointer
 
 public struct AtomicPointer<Pointee>
 {
-  fileprivate var ptr = RawPointer()
+  @_versioned internal var ptr = RawPointer()
   public init(_ pointer: UnsafePointer<Pointee>? = nil)
   {
     StoreRawPtr(pointer, &ptr, memory_order_relaxed)
@@ -219,7 +219,7 @@ extension AtomicPointer
 
 public struct AtomicOpaquePointer
 {
-  fileprivate var ptr = RawPointer()
+  @_versioned internal var ptr = RawPointer()
   public init(_ pointer: OpaquePointer? = nil)
   {
     StoreRawPtr(UnsafeRawPointer(pointer), &ptr, memory_order_relaxed)

--- a/Sources/Atomics/memory-order.swift
+++ b/Sources/Atomics/memory-order.swift
@@ -12,7 +12,7 @@ public enum MemoryOrder: Int
 {
   case relaxed = 0, consume, acquire, release, acqrel, sequential
 
-  public var order: memory_order {
+  @_versioned internal var order: memory_order {
     switch self {
     case .relaxed:    return memory_order_relaxed
     case .consume:    return memory_order_consume
@@ -28,7 +28,7 @@ public enum LoadMemoryOrder: Int
 {
   case relaxed = 0, consume, acquire, sequential = 5
 
-  public var order: memory_order {
+  @_versioned internal var order: memory_order {
     switch self {
     case .relaxed:    return memory_order_relaxed
     case .consume:    return memory_order_consume
@@ -42,7 +42,7 @@ public enum StoreMemoryOrder: Int
 {
   case relaxed = 0, release = 3, sequential = 5
 
-  public var order: memory_order {
+  @_versioned internal var order: memory_order {
     switch self {
     case .relaxed:    return memory_order_relaxed
     case .release:    return memory_order_release


### PR DESCRIPTION
- even though they’re not public (internal appears to be the minimum visibility)
- the MemoryOrder.order property is internal again