### PR TITLE
Memory order enums

### DIFF
--- a/Sources/Atomics/atomics-bool.swift
+++ b/Sources/Atomics/atomics-bool.swift
@@ -18,7 +18,7 @@ public struct AtomicBool
 
   public var value: Bool {
     @inline(__always)
-    mutating get { return AtomicBooleanLoad(&val, memory_order_relaxed) }
+    mutating get { return AtomicBooleanLoad(&val, .relaxed) }
   }
 }
 
@@ -27,37 +27,37 @@ extension AtomicBool
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed)-> Bool
   {
-    return AtomicBooleanLoad(&val, order.order)
+    return AtomicBooleanLoad(&val, order)
   }
 
   @inline(__always)
   public mutating func store(_ value: Bool, order: StoreMemoryOrder = .relaxed)
   {
-    AtomicBooleanStore(value, &val, order.order)
+    AtomicBooleanStore(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func swap(_ value: Bool, order: MemoryOrder = .relaxed)-> Bool
   {
-    return AtomicBooleanSwap(value, &val, order.order)
+    return AtomicBooleanSwap(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func or(_ value: Bool, order: MemoryOrder = .relaxed)-> Bool
   {
-    return AtomicBooleanOr(value, &val, order.order)
+    return AtomicBooleanOr(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func xor(_ value: Bool, order: MemoryOrder = .relaxed)-> Bool
   {
-    return AtomicBooleanXor(value, &val, order.order)
+    return AtomicBooleanXor(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func and(_ value: Bool, order: MemoryOrder = .relaxed)-> Bool
   {
-    return AtomicBooleanAnd(value, &val, order.order)
+    return AtomicBooleanAnd(value, &val, order)
   }
 
   @inline(__always) @discardableResult
@@ -71,9 +71,9 @@ extension AtomicBool
     var expect = current
     switch type {
     case .strong:
-      return AtomicBooleanStrongCAS(&expect, future, &val, orderSwap.order, orderLoad.order)
+      return AtomicBooleanStrongCAS(&expect, future, &val, orderSwap, orderLoad)
     case .weak:
-      return AtomicBooleanWeakCAS(&expect, future, &val, orderSwap.order, orderLoad.order)
+      return AtomicBooleanWeakCAS(&expect, future, &val, orderSwap, orderLoad)
     }
   }
 }

--- a/Sources/Atomics/atomics-fence.swift
+++ b/Sources/Atomics/atomics-fence.swift
@@ -10,5 +10,5 @@ import ClangAtomics
 
 public func threadFence(order: MemoryOrder = .sequential)
 {
-  ThreadFence(order.order)
+  ThreadFence(order)
 }

--- a/Sources/Atomics/atomics-int.swift
+++ b/Sources/Atomics/atomics-int.swift
@@ -18,7 +18,7 @@ public struct AtomicInt
 
   public var value: Int {
     @inline(__always)
-    mutating get { return AtomicWordLoad(&val, memory_order_relaxed) }
+    mutating get { return AtomicWordLoad(&val, .relaxed) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicInt
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordLoad(&val, order.order)
+    return AtomicWordLoad(&val, order)
   }
 
   @inline(__always)
   public mutating func store(_ value: Int, order: StoreMemoryOrder = .relaxed)
   {
-    AtomicWordStore(value, &val, order.order)
+    AtomicWordStore(value, &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordSwap(value, &val, order.order)
+    return AtomicWordSwap(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordAdd(delta, &val, order.order)
+    return AtomicWordAdd(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordAdd(1, &val, order.order)
+    return AtomicWordAdd(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordSub(delta, &val, order.order)
+    return AtomicWordSub(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordSub(1, &val, order.order)
+    return AtomicWordSub(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordOr(bits, &val, order.order)
+    return AtomicWordOr(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordXor(bits, &val, order.order)
+    return AtomicWordXor(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return AtomicWordAnd(bits, &val, order.order)
+    return AtomicWordAnd(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
@@ -94,9 +94,9 @@ extension AtomicInt
     assert(orderSwap == .release ? orderLoad == .relaxed : true)
     switch type {
     case .strong:
-      return AtomicWordStrongCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return AtomicWordStrongCAS(current, future, &val, orderSwap, orderLoad)
     case .weak:
-      return AtomicWordWeakCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return AtomicWordWeakCAS(current, future, &val, orderSwap, orderLoad)
     }
   }
 

--- a/Sources/Atomics/atomics-int32.swift
+++ b/Sources/Atomics/atomics-int32.swift
@@ -18,7 +18,7 @@ public struct AtomicInt32
 
   public var value: Int32 {
     @inline(__always)
-    mutating get { return Atomic32Load(&val, memory_order_relaxed) }
+    mutating get { return Atomic32Load(&val, .relaxed) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicInt32
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Load(&val, order.order)
+    return Atomic32Load(&val, order)
   }
 
   @inline(__always)
   public mutating func store(_ value: Int32, order: StoreMemoryOrder = .relaxed)
   {
-    Atomic32Store(value, &val, order.order)
+    Atomic32Store(value, &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Swap(value, &val, order.order)
+    return Atomic32Swap(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Add(delta, &val, order.order)
+    return Atomic32Add(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Add(1, &val, order.order)
+    return Atomic32Add(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Sub(delta, &val, order.order)
+    return Atomic32Sub(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Sub(1, &val, order.order)
+    return Atomic32Sub(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Or(bits, &val, order.order)
+    return Atomic32Or(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32Xor(bits, &val, order.order)
+    return Atomic32Xor(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return Atomic32And(bits, &val, order.order)
+    return Atomic32And(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
@@ -94,9 +94,9 @@ extension AtomicInt32
     assert(orderSwap == .release ? orderLoad == .relaxed : true)
     switch type {
     case .strong:
-      return Atomic32StrongCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return Atomic32StrongCAS(current, future, &val, orderSwap, orderLoad)
     case .weak:
-      return Atomic32WeakCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return Atomic32WeakCAS(current, future, &val, orderSwap, orderLoad)
     }
   }
 

--- a/Sources/Atomics/atomics-int64.swift
+++ b/Sources/Atomics/atomics-int64.swift
@@ -18,7 +18,7 @@ public struct AtomicInt64
 
   public var value: Int64 {
     @inline(__always)
-    mutating get { return Atomic64Load(&val, memory_order_relaxed) }
+    mutating get { return Atomic64Load(&val, .relaxed) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicInt64
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Load(&val, order.order)
+    return Atomic64Load(&val, order)
   }
 
   @inline(__always)
   public mutating func store(_ value: Int64, order: StoreMemoryOrder = .relaxed)
   {
-    Atomic64Store(value, &val, order.order)
+    Atomic64Store(value, &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Swap(value, &val, order.order)
+    return Atomic64Swap(value, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Add(delta, &val, order.order)
+    return Atomic64Add(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Add(1, &val, order.order)
+    return Atomic64Add(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Sub(delta, &val, order.order)
+    return Atomic64Sub(delta, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Sub(1, &val, order.order)
+    return Atomic64Sub(1, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Or(bits, &val, order.order)
+    return Atomic64Or(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64Xor(bits, &val, order.order)
+    return Atomic64Xor(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return Atomic64And(bits, &val, order.order)
+    return Atomic64And(bits, &val, order)
   }
 
   @inline(__always) @discardableResult
@@ -94,9 +94,9 @@ extension AtomicInt64
     assert(orderSwap == .release ? orderLoad == .relaxed : true)
     switch type {
     case .strong:
-      return Atomic64StrongCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return Atomic64StrongCAS(current, future, &val, orderSwap, orderLoad)
     case .weak:
-      return Atomic64WeakCAS(current, future, &val, orderSwap.order, orderLoad.order)
+      return Atomic64WeakCAS(current, future, &val, orderSwap, orderLoad)
     }
   }
 

--- a/Sources/Atomics/atomics-pointer.swift
+++ b/Sources/Atomics/atomics-pointer.swift
@@ -20,7 +20,7 @@ public struct AtomicMutableRawPointer
   public var pointer: UnsafeMutableRawPointer? {
     @inline(__always)
     mutating get {
-      return AtomicPointerLoad(&ptr, memory_order_relaxed)
+      return AtomicPointerLoad(&ptr, .relaxed)
     }
   }
 }
@@ -30,19 +30,19 @@ extension AtomicMutableRawPointer
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> UnsafeMutableRawPointer?
   {
-    return AtomicPointerLoad(&ptr, order.order)
+    return AtomicPointerLoad(&ptr, order)
   }
 
   @inline(__always)
   public mutating func store(_ pointer: UnsafeMutableRawPointer?, order: StoreMemoryOrder = .sequential)
   {
-    AtomicPointerStore(pointer, &ptr, order.order)
+    AtomicPointerStore(pointer, &ptr, order)
   }
 
   @inline(__always)
   public mutating func swap(_ pointer: UnsafeMutableRawPointer?, order: MemoryOrder = .sequential) -> UnsafeMutableRawPointer?
   {
-    return AtomicPointerSwap(pointer, &ptr, order.order)
+    return AtomicPointerSwap(pointer, &ptr, order)
   }
 
   @inline(__always) @discardableResult
@@ -58,9 +58,9 @@ extension AtomicMutableRawPointer
       current in
       switch type {
       case .strong:
-        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap, orderLoad)
       case .weak:
-        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap, orderLoad)
       }
     }
   }
@@ -86,7 +86,7 @@ public struct AtomicRawPointer
   public var pointer: UnsafeRawPointer? {
     @inline(__always)
     mutating get {
-      return UnsafeRawPointer(AtomicPointerLoad(&ptr, memory_order_relaxed))
+      return UnsafeRawPointer(AtomicPointerLoad(&ptr, LoadMemoryOrder.relaxed))
     }
   }
 }
@@ -96,19 +96,19 @@ extension AtomicRawPointer
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> UnsafeRawPointer?
   {
-    return UnsafeRawPointer(AtomicPointerLoad(&ptr, order.order))
+    return UnsafeRawPointer(AtomicPointerLoad(&ptr, order))
   }
 
   @inline(__always)
   public mutating func store(_ pointer: UnsafeRawPointer?, order: StoreMemoryOrder = .sequential)
   {
-    AtomicPointerStore(pointer, &ptr, order.order)
+    AtomicPointerStore(pointer, &ptr, order)
   }
 
   @inline(__always)
   public mutating func swap(_ pointer: UnsafeRawPointer?, order: MemoryOrder = .sequential) -> UnsafeRawPointer?
   {
-    return UnsafeRawPointer(AtomicPointerSwap(pointer, &ptr, order.order))
+    return UnsafeRawPointer(AtomicPointerSwap(pointer, &ptr, order))
   }
 
   @inline(__always) @discardableResult
@@ -122,9 +122,9 @@ extension AtomicRawPointer
     assert(orderSwap == .release ? orderLoad == .relaxed : true)
     switch type {
     case .strong:
-      return AtomicPointerStrongCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+      return AtomicPointerStrongCAS(current, future, &ptr, orderSwap, orderLoad)
     case .weak:
-      return AtomicPointerWeakCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+      return AtomicPointerWeakCAS(current, future, &ptr, orderSwap, orderLoad)
     }
   }
 
@@ -149,7 +149,7 @@ public struct AtomicMutablePointer<Pointee>
   public var pointer: UnsafeMutablePointer<Pointee>? {
     @inline(__always)
     mutating get {
-      return AtomicPointerLoad(&ptr, memory_order_relaxed)?.assumingMemoryBound(to: Pointee.self)
+      return AtomicPointerLoad(&ptr, LoadMemoryOrder.relaxed)?.assumingMemoryBound(to: Pointee.self)
     }
   }
 }
@@ -159,19 +159,19 @@ extension AtomicMutablePointer
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> UnsafeMutablePointer<Pointee>?
   {
-    return AtomicPointerLoad(&ptr, order.order)?.assumingMemoryBound(to: Pointee.self)
+    return AtomicPointerLoad(&ptr, order)?.assumingMemoryBound(to: Pointee.self)
   }
 
   @inline(__always)
   public mutating func store(_ pointer: UnsafeMutablePointer<Pointee>?, order: StoreMemoryOrder = .sequential)
   {
-    AtomicPointerStore(pointer, &ptr, order.order)
+    AtomicPointerStore(pointer, &ptr, order)
   }
 
   @inline(__always)
   public mutating func swap(_ pointer: UnsafeMutablePointer<Pointee>?, order: MemoryOrder = .sequential) -> UnsafeMutablePointer<Pointee>?
   {
-    return AtomicPointerSwap(pointer, &ptr, order.order)?.assumingMemoryBound(to: Pointee.self)
+    return AtomicPointerSwap(pointer, &ptr, order)?.assumingMemoryBound(to: Pointee.self)
   }
 
   @inline(__always) @discardableResult
@@ -187,9 +187,9 @@ extension AtomicMutablePointer
       current in
       switch type {
       case .strong:
-        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap, orderLoad)
       case .weak:
-        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap, orderLoad)
       }
     }
   }
@@ -215,7 +215,7 @@ public struct AtomicPointer<Pointee>
   public var pointer: UnsafePointer<Pointee>? {
     @inline(__always)
     mutating get {
-      return UnsafePointer(AtomicPointerLoad(&ptr, memory_order_relaxed)?.assumingMemoryBound(to: Pointee.self))
+      return UnsafePointer(AtomicPointerLoad(&ptr, LoadMemoryOrder.relaxed)?.assumingMemoryBound(to: Pointee.self))
     }
   }
 }
@@ -225,19 +225,19 @@ extension AtomicPointer
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> UnsafePointer<Pointee>?
   {
-    return UnsafePointer(AtomicPointerLoad(&ptr, order.order)?.assumingMemoryBound(to: Pointee.self))
+    return UnsafePointer(AtomicPointerLoad(&ptr, order)?.assumingMemoryBound(to: Pointee.self))
   }
 
   @inline(__always)
   public mutating func store(_ pointer: UnsafePointer<Pointee>?, order: StoreMemoryOrder = .sequential)
   {
-    AtomicPointerStore(pointer, &ptr, order.order)
+    AtomicPointerStore(pointer, &ptr, order)
   }
 
   @inline(__always)
   public mutating func swap(_ pointer: UnsafePointer<Pointee>?, order: MemoryOrder = .sequential) -> UnsafePointer<Pointee>?
   {
-    return UnsafePointer(AtomicPointerSwap(pointer, &ptr, order.order)?.assumingMemoryBound(to: Pointee.self))
+    return UnsafePointer(AtomicPointerSwap(pointer, &ptr, order)?.assumingMemoryBound(to: Pointee.self))
   }
 
   @inline(__always) @discardableResult
@@ -253,9 +253,9 @@ extension AtomicPointer
       current in
       switch type {
       case .strong:
-        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerStrongCAS(current, future, &ptr, orderSwap, orderLoad)
       case .weak:
-        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerWeakCAS(current, future, &ptr, orderSwap, orderLoad)
       }
     }
   }
@@ -281,7 +281,7 @@ public struct AtomicOpaquePointer
   public var pointer: OpaquePointer? {
     @inline(__always)
     mutating get {
-      return OpaquePointer(AtomicPointerLoad(&ptr, memory_order_relaxed))
+      return OpaquePointer(AtomicPointerLoad(&ptr, LoadMemoryOrder.relaxed))
     }
   }
 }
@@ -291,19 +291,19 @@ extension AtomicOpaquePointer
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> OpaquePointer?
   {
-    return OpaquePointer(AtomicPointerLoad(&ptr, order.order))
+    return OpaquePointer(AtomicPointerLoad(&ptr, order))
   }
 
   @inline(__always)
   public mutating func store(_ pointer: OpaquePointer?, order: StoreMemoryOrder = .sequential)
   {
-    AtomicPointerStore(UnsafePointer(pointer), &ptr, order.order)
+    AtomicPointerStore(UnsafePointer(pointer), &ptr, order)
   }
 
   @inline(__always)
   public mutating func swap(_ pointer: OpaquePointer?, order: MemoryOrder = .sequential) -> OpaquePointer?
   {
-    return OpaquePointer(AtomicPointerSwap(UnsafePointer(pointer), &ptr, order.order))
+    return OpaquePointer(AtomicPointerSwap(UnsafePointer(pointer), &ptr, order))
   }
 
   @inline(__always) @discardableResult
@@ -319,9 +319,9 @@ extension AtomicOpaquePointer
       current in
       switch type {
       case .strong:
-        return AtomicPointerStrongCAS(current, UnsafePointer(future), &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerStrongCAS(current, UnsafePointer(future), &ptr, orderSwap, orderLoad)
       case .weak:
-        return AtomicPointerWeakCAS(current, UnsafePointer(future), &ptr, orderSwap.order, orderLoad.order)
+        return AtomicPointerWeakCAS(current, UnsafePointer(future), &ptr, orderSwap, orderLoad)
       }
     }
   }

--- a/Sources/Atomics/atomics-reference.swift
+++ b/Sources/Atomics/atomics-reference.swift
@@ -25,7 +25,7 @@ extension AtomicReference
   public mutating func swap(_ ref: T?, order: MemoryOrder = .sequential) -> T?
   {
     let u = Unmanaged.tryRetain(ref)?.toOpaque()
-    if let pointer = AtomicPointerSwap(u, &ptr, order.order)
+    if let pointer = AtomicPointerSwap(u, &ptr, order)
     {
       return Unmanaged<T>.fromOpaque(pointer).takeRetainedValue()
     }
@@ -37,7 +37,7 @@ extension AtomicReference
   {
     let u = Unmanaged.passUnretained(ref)
     var null: UnsafeRawPointer? = nil
-    if AtomicPointerStrongCAS(&null, u.toOpaque(), &ptr, order.order, memory_order_relaxed)
+    if AtomicPointerStrongCAS(&null, u.toOpaque(), &ptr, order, .relaxed)
     {
       _ = u.retain()
       return true
@@ -48,7 +48,7 @@ extension AtomicReference
   @inline(__always)
   public mutating func take(order: MemoryOrder = .sequential) -> T?
   {
-    if let pointer = AtomicPointerSwap(nil, &ptr, order.order)
+    if let pointer = AtomicPointerSwap(nil, &ptr, order)
     {
       return Unmanaged<T>.fromOpaque(pointer).takeRetainedValue()
     }

--- a/Sources/Atomics/atomics-uint.swift
+++ b/Sources/Atomics/atomics-uint.swift
@@ -18,7 +18,7 @@ public struct AtomicUInt
 
   public var value: UInt {
     @inline(__always)
-    mutating get { return UInt(bitPattern: AtomicWordLoad(&val, memory_order_relaxed)) }
+    mutating get { return UInt(bitPattern: AtomicWordLoad(&val, .relaxed)) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicUInt
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordLoad(&val, order.order))
+    return UInt(bitPattern: AtomicWordLoad(&val, order))
   }
 
   @inline(__always)
   public mutating func store(_ value: UInt, order: StoreMemoryOrder = .relaxed)
   {
-    AtomicWordStore(Int(bitPattern: value), &val, order.order)
+    AtomicWordStore(Int(bitPattern: value), &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordSwap(Int(bitPattern: value), &val, order.order))
+    return UInt(bitPattern: AtomicWordSwap(Int(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ value: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordAdd(Int(bitPattern: value), &val, order.order))
+    return UInt(bitPattern: AtomicWordAdd(Int(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordAdd(1, &val, order.order))
+    return UInt(bitPattern: AtomicWordAdd(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ value: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordSub(Int(bitPattern: value), &val, order.order))
+    return UInt(bitPattern: AtomicWordSub(Int(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordSub(1, &val, order.order))
+    return UInt(bitPattern: AtomicWordSub(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits:UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordOr(Int(bitPattern: bits), &val, order.order))
+    return UInt(bitPattern: AtomicWordOr(Int(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits:UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordXor(Int(bitPattern: bits), &val, order.order))
+    return UInt(bitPattern: AtomicWordXor(Int(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits:UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return UInt(bitPattern: AtomicWordAnd(Int(bitPattern: bits), &val, order.order))
+    return UInt(bitPattern: AtomicWordAnd(Int(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
@@ -96,9 +96,9 @@ extension AtomicUInt
       current in
       switch type {
       case .strong:
-        return AtomicWordStrongCAS(current, Int(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return AtomicWordStrongCAS(current, Int(bitPattern: future), &val, orderSwap, orderLoad)
       case .weak:
-        return AtomicWordWeakCAS(current, Int(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return AtomicWordWeakCAS(current, Int(bitPattern: future), &val, orderSwap, orderLoad)
       }
     }
   }

--- a/Sources/Atomics/atomics-uint32.swift
+++ b/Sources/Atomics/atomics-uint32.swift
@@ -18,7 +18,7 @@ public struct AtomicUInt32
 
   public var value: UInt32 {
     @inline(__always)
-    mutating get { return UInt32(bitPattern: Atomic32Load(&val, memory_order_relaxed)) }
+    mutating get { return UInt32(bitPattern: Atomic32Load(&val, .relaxed)) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicUInt32
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Load(&val, order.order))
+    return UInt32(bitPattern: Atomic32Load(&val, order))
   }
 
   @inline(__always)
   public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .relaxed)
   {
-    Atomic32Store(Int32(bitPattern: value), &val, order.order)
+    Atomic32Store(Int32(bitPattern: value), &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Swap(Int32(bitPattern: value), &val, order.order))
+    return UInt32(bitPattern: Atomic32Swap(Int32(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ value: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Add(Int32(bitPattern: value), &val, order.order))
+    return UInt32(bitPattern: Atomic32Add(Int32(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Add(1, &val, order.order))
+    return UInt32(bitPattern: Atomic32Add(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ value: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Sub(Int32(bitPattern: value), &val, order.order))
+    return UInt32(bitPattern: Atomic32Sub(Int32(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Sub(1, &val, order.order))
+    return UInt32(bitPattern: Atomic32Sub(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits:UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Or(Int32(bitPattern: bits), &val, order.order))
+    return UInt32(bitPattern: Atomic32Or(Int32(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits:UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32Xor(Int32(bitPattern: bits), &val, order.order))
+    return UInt32(bitPattern: Atomic32Xor(Int32(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits:UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return UInt32(bitPattern: Atomic32And(Int32(bitPattern: bits), &val, order.order))
+    return UInt32(bitPattern: Atomic32And(Int32(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
@@ -96,9 +96,9 @@ extension AtomicUInt32
       current in
       switch type {
       case .strong:
-        return Atomic32StrongCAS(current, Int32(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return Atomic32StrongCAS(current, Int32(bitPattern: future), &val, orderSwap, orderLoad)
       case .weak:
-        return Atomic32WeakCAS(current, Int32(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return Atomic32WeakCAS(current, Int32(bitPattern: future), &val, orderSwap, orderLoad)
       }
     }
   }

--- a/Sources/Atomics/atomics-uint64.swift
+++ b/Sources/Atomics/atomics-uint64.swift
@@ -18,7 +18,7 @@ public struct AtomicUInt64
 
   public var value: UInt64 {
     @inline(__always)
-    mutating get { return UInt64(bitPattern: Atomic64Load(&val, memory_order_relaxed)) }
+    mutating get { return UInt64(bitPattern: Atomic64Load(&val, .relaxed)) }
   }
 }
 
@@ -27,61 +27,61 @@ extension AtomicUInt64
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Load(&val, order.order))
+    return UInt64(bitPattern: Atomic64Load(&val, order))
   }
 
   @inline(__always)
   public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .relaxed)
   {
-    Atomic64Store(Int64(bitPattern: value), &val, order.order)
+    Atomic64Store(Int64(bitPattern: value), &val, order)
   }
 
   @inline(__always)
   public mutating func swap(_ value: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Swap(Int64(bitPattern: value), &val, order.order))
+    return UInt64(bitPattern: Atomic64Swap(Int64(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func add(_ value: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Add(Int64(bitPattern: value), &val, order.order))
+    return UInt64(bitPattern: Atomic64Add(Int64(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Add(1, &val, order.order))
+    return UInt64(bitPattern: Atomic64Add(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func subtract(_ value: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Sub(Int64(bitPattern: value), &val, order.order))
+    return UInt64(bitPattern: Atomic64Sub(Int64(bitPattern: value), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Sub(1, &val, order.order))
+    return UInt64(bitPattern: Atomic64Sub(1, &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits:UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Or(Int64(bitPattern: bits), &val, order.order))
+    return UInt64(bitPattern: Atomic64Or(Int64(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits:UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64Xor(Int64(bitPattern: bits), &val, order.order))
+    return UInt64(bitPattern: Atomic64Xor(Int64(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits:UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return UInt64(bitPattern: Atomic64And(Int64(bitPattern: bits), &val, order.order))
+    return UInt64(bitPattern: Atomic64And(Int64(bitPattern: bits), &val, order))
   }
 
   @inline(__always) @discardableResult
@@ -96,9 +96,9 @@ extension AtomicUInt64
       current in
       switch type {
       case .strong:
-        return Atomic64StrongCAS(current, Int64(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return Atomic64StrongCAS(current, Int64(bitPattern: future), &val, orderSwap, orderLoad)
       case .weak:
-        return Atomic64WeakCAS(current, Int64(bitPattern: future), &val, orderSwap.order, orderLoad.order)
+        return Atomic64WeakCAS(current, Int64(bitPattern: future), &val, orderSwap, orderLoad)
       }
     }
   }

--- a/Sources/Atomics/memory-order.swift
+++ b/Sources/Atomics/memory-order.swift
@@ -8,45 +8,27 @@
 
 import ClangAtomics
 
-public enum MemoryOrder: UInt32
+extension MemoryOrder
 {
-  case relaxed = 0, /* consume, */ acquire = 2, release, acqrel, sequential
-
-  @_versioned internal var order: memory_order {
-    switch self {
-    case .relaxed:    return memory_order_relaxed
-    // case .consume: return memory_order_consume
-    case .acquire:    return memory_order_acquire
-    case .release:    return memory_order_release
-    case .acqrel:     return memory_order_acq_rel
-    case .sequential: return memory_order_seq_cst
-    }
-  }
+  public static var relaxed:    MemoryOrder { return clang_atomics_memory_order_relaxed }
+//public static var consume:    MemoryOrder { return clang_atomics_memory_order_consume }
+  public static var acquire:    MemoryOrder { return clang_atomics_memory_order_acquire }
+  public static var release:    MemoryOrder { return clang_atomics_memory_order_release }
+  public static var acqrel:     MemoryOrder { return clang_atomics_memory_order_acq_rel }
+  public static var sequential: MemoryOrder { return clang_atomics_memory_order_seq_cst }
 }
 
-public enum LoadMemoryOrder: UInt32
+extension LoadMemoryOrder
 {
-  case relaxed = 0, /* consume, */ acquire = 2, sequential = 5
-
-  @_versioned internal var order: memory_order {
-    switch self {
-    case .relaxed:    return memory_order_relaxed
-    // case .consume: return memory_order_consume
-    case .acquire:    return memory_order_acquire
-    case .sequential: return memory_order_seq_cst
-    }
-  }
+  public static var relaxed:    LoadMemoryOrder { return clang_atomics_load_memory_order_relaxed }
+//public static var consume:    LoadMemoryOrder { return clang_atomics_load_memory_order_consume }
+  public static var acquire:    LoadMemoryOrder { return clang_atomics_load_memory_order_acquire }
+  public static var sequential: LoadMemoryOrder { return clang_atomics_load_memory_order_seq_cst }
 }
 
-public enum StoreMemoryOrder: UInt32
+extension StoreMemoryOrder
 {
-  case relaxed = 0, release = 3, sequential = 5
-
-  @_versioned internal var order: memory_order {
-    switch self {
-    case .relaxed:    return memory_order_relaxed
-    case .release:    return memory_order_release
-    case .sequential: return memory_order_seq_cst
-    }
-  }
+  public static var relaxed:    StoreMemoryOrder { return clang_atomics_store_memory_order_relaxed }
+  public static var release:    StoreMemoryOrder { return clang_atomics_store_memory_order_release }
+  public static var sequential: StoreMemoryOrder { return clang_atomics_store_memory_order_seq_cst }
 }

--- a/Sources/ClangAtomics/include/ClangAtomics.h
+++ b/Sources/ClangAtomics/include/ClangAtomics.h
@@ -72,74 +72,71 @@ _Bool AtomicPointerWeakCAS(const void* _Nullable* _Nonnull current, const void* 
 
 // integer atomics generation
 
-#define CLANG_ATOMIC_STRUCT(sType, mType) \
-        typedef struct { volatile mType a; } sType;
+#define CLANG_ATOMICS_STRUCT(sType, aType) \
+        typedef struct { volatile aType a; } sType;
 
-#define CLANG_ATOMIC_INIT(sType, pType) \
+#define CLANG_ATOMICS_INIT(sType, pType) \
         static __inline__ __attribute__((__always_inline__)) \
         void sType##Init(pType value, sType *_Nonnull ptr) \
         { atomic_init(&(ptr->a), value); }
 
-#define CLANG_ATOMIC_LOAD(sType, pType) \
+#define CLANG_ATOMICS_LOAD(sType, pType) \
         static __inline__ __attribute__((__always_inline__)) \
         pType sType##Load(sType *_Nonnull ptr, memory_order order) \
         { return atomic_load_explicit(&(ptr->a), order); }
 
-#define CLANG_ATOMIC_STORE(sType, pType) \
+#define CLANG_ATOMICS_STORE(sType, pType) \
         static __inline__ __attribute__((__always_inline__)) \
         void sType##Store(pType value, sType *_Nonnull ptr, memory_order order) \
         { atomic_store_explicit(&(ptr->a), value, order); }
 
-#define CLANG_ATOMIC_RMW(sType, pType, pName, op, opName) \
+#define CLANG_ATOMICS_RMW(sType, pType, pName, op, opName) \
         static __inline__ __attribute__((__always_inline__)) \
         pType sType##opName(pType pName, sType *_Nonnull ptr, memory_order order) \
         { return atomic_##op##_explicit(&(ptr->a), pName, order); }
 
-#define CLANG_ATOMIC_CAS(sType, pType, strength, strName) \
+#define CLANG_ATOMICS_CAS(sType, pType, strength, strName) \
         static __inline__ __attribute__((__always_inline__)) \
         _Bool sType##strName##CAS(pType *_Nonnull current, pType future, sType *_Nonnull ptr, \
                                   memory_order succ, memory_order fail) \
         { return atomic_compare_exchange_##strength##_explicit(&(ptr->a), current, future, succ, fail); }
 
-#define CLANG_ATOMIC_GENERATE(sType, pType) \
-        CLANG_ATOMIC_INIT(sType, pType) \
-        CLANG_ATOMIC_LOAD(sType, pType) \
-        CLANG_ATOMIC_STORE(sType, pType) \
-        CLANG_ATOMIC_RMW(sType, pType, value, exchange, Swap) \
-        CLANG_ATOMIC_RMW(sType, pType, increment, fetch_add, Add) \
-        CLANG_ATOMIC_RMW(sType, pType, increment, fetch_sub, Sub) \
-        CLANG_ATOMIC_RMW(sType, pType, bits, fetch_or, Or) \
-        CLANG_ATOMIC_RMW(sType, pType, bits, fetch_xor, Xor) \
-        CLANG_ATOMIC_RMW(sType, pType, bits, fetch_and, And) \
-        CLANG_ATOMIC_CAS(sType, pType, strong, Strong) \
-        CLANG_ATOMIC_CAS(sType, pType, weak, Weak)
+#define CLANG_ATOMICS_GENERATE(sType, aType, pType) \
+        CLANG_ATOMICS_STRUCT(sType, aType) \
+        CLANG_ATOMICS_INIT(sType, pType) \
+        CLANG_ATOMICS_LOAD(sType, pType) \
+        CLANG_ATOMICS_STORE(sType, pType) \
+        CLANG_ATOMICS_RMW(sType, pType, value, exchange, Swap) \
+        CLANG_ATOMICS_RMW(sType, pType, increment, fetch_add, Add) \
+        CLANG_ATOMICS_RMW(sType, pType, increment, fetch_sub, Sub) \
+        CLANG_ATOMICS_RMW(sType, pType, bits, fetch_or, Or) \
+        CLANG_ATOMICS_RMW(sType, pType, bits, fetch_xor, Xor) \
+        CLANG_ATOMICS_RMW(sType, pType, bits, fetch_and, And) \
+        CLANG_ATOMICS_CAS(sType, pType, strong, Strong) \
+        CLANG_ATOMICS_CAS(sType, pType, weak, Weak)
 
 // integer atomics
 
-CLANG_ATOMIC_STRUCT(AtomicWord, atomic_long)
-CLANG_ATOMIC_GENERATE(AtomicWord, long)
+CLANG_ATOMICS_GENERATE(AtomicWord, atomic_long, long)
 
-CLANG_ATOMIC_STRUCT(Atomic8, atomic_char)
-CLANG_ATOMIC_GENERATE(Atomic8, char)
+CLANG_ATOMICS_GENERATE(Atomic8, atomic_char, char)
 
-CLANG_ATOMIC_STRUCT(Atomic32, atomic_int)
-CLANG_ATOMIC_GENERATE(Atomic32, int)
+CLANG_ATOMICS_GENERATE(Atomic32, atomic_int, int)
 
-CLANG_ATOMIC_STRUCT(Atomic64, atomic_llong)
-CLANG_ATOMIC_GENERATE(Atomic64, long long)
+CLANG_ATOMICS_GENERATE(Atomic64, atomic_llong, long long)
 
 // bool atomics
 
-CLANG_ATOMIC_STRUCT(AtomicBoolean, atomic_bool)
-CLANG_ATOMIC_INIT(AtomicBoolean, _Bool)
-CLANG_ATOMIC_LOAD(AtomicBoolean, _Bool)
-CLANG_ATOMIC_STORE(AtomicBoolean, _Bool)
-CLANG_ATOMIC_RMW(AtomicBoolean, _Bool, value, exchange, Swap)
-CLANG_ATOMIC_RMW(AtomicBoolean, _Bool, value, fetch_or, Or)
-CLANG_ATOMIC_RMW(AtomicBoolean, _Bool, value, fetch_xor, Xor)
-CLANG_ATOMIC_RMW(AtomicBoolean, _Bool, value, fetch_and, And)
-CLANG_ATOMIC_CAS(AtomicBoolean, _Bool, strong, Strong)
-CLANG_ATOMIC_CAS(AtomicBoolean, _Bool, weak, Weak)
+CLANG_ATOMICS_STRUCT(AtomicBoolean, atomic_bool)
+CLANG_ATOMICS_INIT(AtomicBoolean, _Bool)
+CLANG_ATOMICS_LOAD(AtomicBoolean, _Bool)
+CLANG_ATOMICS_STORE(AtomicBoolean, _Bool)
+CLANG_ATOMICS_RMW(AtomicBoolean, _Bool, value, exchange, Swap)
+CLANG_ATOMICS_RMW(AtomicBoolean, _Bool, value, fetch_or, Or)
+CLANG_ATOMICS_RMW(AtomicBoolean, _Bool, value, fetch_xor, Xor)
+CLANG_ATOMICS_RMW(AtomicBoolean, _Bool, value, fetch_and, And)
+CLANG_ATOMICS_CAS(AtomicBoolean, _Bool, strong, Strong)
+CLANG_ATOMICS_CAS(AtomicBoolean, _Bool, weak, Weak)
 
 // fence
 

--- a/Tests/AtomicsTests/MemoryOrderTests.swift
+++ b/Tests/AtomicsTests/MemoryOrderTests.swift
@@ -19,6 +19,10 @@ class MemoryOrderTests: XCTestCase
 
   func testMemoryOrder()
   {
+    let m = MemoryOrder(rawValue: memory_order_relaxed.rawValue)
+    XCTAssert(m == clang_atomics_memory_order_relaxed)
+    XCTAssert(m == .relaxed)
+
     XCTAssert(MemoryOrder.relaxed.rawValue == memory_order_relaxed.rawValue)
     XCTAssert(MemoryOrder.acquire.rawValue == memory_order_acquire.rawValue)
     XCTAssert(MemoryOrder.release.rawValue == memory_order_release.rawValue)

--- a/Tests/ClangAtomicsTests/ClangAtomicsTests.swift
+++ b/Tests/ClangAtomicsTests/ClangAtomicsTests.swift
@@ -38,12 +38,12 @@ class ClangAtomicsTests: XCTestCase
   func testTest()
   {
     var i = AtomicWord()
-    AtomicWordStore(0, &i, memory_order_relaxed)
-    XCTAssert(AtomicWordLoad(&i, memory_order_relaxed) == 0)
+    AtomicWordStore(0, &i, clang_atomics_store_memory_order_relaxed)
+    XCTAssert(AtomicWordLoad(&i, clang_atomics_load_memory_order_relaxed) == 0)
 
     let r = randomPositive()
-    AtomicWordStore(r, &i, memory_order_relaxed)
-    XCTAssert(AtomicWordLoad(&i, memory_order_relaxed) == r)
+    AtomicWordStore(r, &i, clang_atomics_store_memory_order_relaxed)
+    XCTAssert(AtomicWordLoad(&i, clang_atomics_load_memory_order_relaxed) == r)
   }
 }
 
@@ -61,14 +61,14 @@ class ClangAtomicsRaceTests: XCTestCase
     {
       var p: Optional = UnsafeMutablePointer<Point>.allocate(capacity: 1)
       var lock = AtomicWord()
-      AtomicWordStore(0, &lock, memory_order_relaxed)
+      AtomicWordStore(0, &lock, clang_atomics_store_memory_order_relaxed)
       let closure = {
         while true
         {
           var current = 0
-          if AtomicWordWeakCAS(&current, 1, &lock, memory_order_seq_cst, memory_order_relaxed)
+          if AtomicWordWeakCAS(&current, 1, &lock, clang_atomics_memory_order_seq_cst, clang_atomics_load_memory_order_relaxed)
           {
-            defer { AtomicWordStore(0, &lock, memory_order_seq_cst) }
+            defer { AtomicWordStore(0, &lock, clang_atomics_store_memory_order_seq_cst) }
             if let c = p
             {
               p = nil


### PR DESCRIPTION
It would be nicer to export the C enums as Swift enums, but I haven't found a way to do it that works on Linux. `__attribute((swift_name("name")))` is not in upstream clang at this time.