### PR TITLE
Warnings cleanup

### DIFF
--- a/Sources/Atomics/atomics-integer.swift
+++ b/Sources/Atomics/atomics-integer.swift
@@ -14,7 +14,10 @@ import CAtomics
 extension AtomicInt
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Int) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int) {}
+  public init(_ value: Int)
+  {
+    self.init()
+  }
 
   public var value: Int {
     @inline(__always)
@@ -104,7 +107,10 @@ extension AtomicInt
 extension AtomicUInt
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: UInt) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt) {}
+  public init(_ value: UInt)
+  {
+    self.init()
+  }
 
   public var value: UInt {
     @inline(__always)
@@ -194,7 +200,10 @@ extension AtomicUInt
 extension AtomicInt8
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Int8) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int8) {}
+  public init(_ value: Int8)
+  {
+    self.init()
+  }
 
   public var value: Int8 {
     @inline(__always)
@@ -284,7 +293,10 @@ extension AtomicInt8
 extension AtomicUInt8
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: UInt8) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt8) {}
+  public init(_ value: UInt8)
+  {
+    self.init()
+  }
 
   public var value: UInt8 {
     @inline(__always)
@@ -374,7 +386,10 @@ extension AtomicUInt8
 extension AtomicInt16
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Int16) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int16) {}
+  public init(_ value: Int16)
+  {
+    self.init()
+  }
 
   public var value: Int16 {
     @inline(__always)
@@ -464,7 +479,10 @@ extension AtomicInt16
 extension AtomicUInt16
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: UInt16) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt16) {}
+  public init(_ value: UInt16)
+  {
+    self.init()
+  }
 
   public var value: UInt16 {
     @inline(__always)
@@ -554,7 +572,10 @@ extension AtomicUInt16
 extension AtomicInt32
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Int32) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int32) {}
+  public init(_ value: Int32)
+  {
+    self.init()
+  }
 
   public var value: Int32 {
     @inline(__always)
@@ -644,7 +665,10 @@ extension AtomicInt32
 extension AtomicUInt32
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: UInt32) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt32) {}
+  public init(_ value: UInt32)
+  {
+    self.init()
+  }
 
   public var value: UInt32 {
     @inline(__always)
@@ -734,7 +758,10 @@ extension AtomicUInt32
 extension AtomicInt64
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Int64) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int64) {}
+  public init(_ value: Int64)
+  {
+    self.init()
+  }
 
   public var value: Int64 {
     @inline(__always)
@@ -824,7 +851,10 @@ extension AtomicInt64
 extension AtomicUInt64
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: UInt64) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt64) {}
+  public init(_ value: UInt64)
+  {
+    self.init()
+  }
 
   public var value: UInt64 {
     @inline(__always)
@@ -914,7 +944,10 @@ extension AtomicUInt64
 extension AtomicBool
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: Bool) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Bool) {}
+  public init(_ value: Bool)
+  {
+    self.init()
+  }
 
   public var value: Bool {
     @inline(__always)

--- a/Sources/Atomics/atomics-integer.swift.gyb
+++ b/Sources/Atomics/atomics-integer.swift.gyb
@@ -16,7 +16,10 @@ import CAtomics
 extension ${AtomicType}
 {
   @available(*, unavailable, message: "If needed, use initialize(_ value: ${IntType}) after the default initializer, as long as the instance is unshared")
-  public init(_ value: ${IntType}) {}
+  public init(_ value: ${IntType})
+  {
+    self.init()
+  }
 
   public var value: ${IntType} {
     @inline(__always)

--- a/Sources/Atomics/atomics-pointer.swift
+++ b/Sources/Atomics/atomics-pointer.swift
@@ -134,7 +134,10 @@ public struct AtomicMutablePointer<Pointee>
 extension AtomicRawPointer
 {
   @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeRawPointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeRawPointer?) {}
+  public init(_ pointer: UnsafeRawPointer?)
+  {
+    self.init()
+  }
 
   public var pointer: UnsafeRawPointer? {
     @inline(__always)
@@ -185,7 +188,10 @@ extension AtomicRawPointer
 extension AtomicMutableRawPointer
 {
   @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeMutableRawPointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeMutableRawPointer?) {}
+  public init(_ pointer: UnsafeMutableRawPointer?)
+  {
+    self.init()
+  }
 
   public var pointer: UnsafeMutableRawPointer? {
     @inline(__always)
@@ -236,7 +242,10 @@ extension AtomicMutableRawPointer
 extension AtomicOpaquePointer
 {
   @available(*, unavailable, message: "If needed, use initialize(_ pointer: OpaquePointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: OpaquePointer?) {}
+  public init(_ pointer: OpaquePointer?)
+  {
+    self.init()
+  }
 
   public var pointer: OpaquePointer? {
     @inline(__always)

--- a/Sources/Atomics/atomics-pointer.swift.gyb
+++ b/Sources/Atomics/atomics-pointer.swift.gyb
@@ -77,7 +77,10 @@ public struct Atomic${Mutable}Pointer<Pointee>
 extension ${AtomicType}
 {
   @available(*, unavailable, message: "If needed, use initialize(_ pointer: ${PointerType}?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: ${PointerType}?) {}
+  public init(_ pointer: ${PointerType}?)
+  {
+    self.init()
+  }
 
   public var pointer: ${PointerType}? {
     @inline(__always)


### PR DESCRIPTION
Hey 👋
In latest Xcode 9.3 there's a warning about lack of explicit initialization, and using most recent Swift snapshot compilation in release is failing due to some asserts, so I thought it might be good to update it :) 