### PR TITLE
add a load() operation to AtomicReference

### DIFF
--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -315,7 +315,8 @@ const void *_Nullable RawUnmanagedSpinLoad(RawUnmanaged *_Nonnull ptr, enum Spin
 #endif
       pointer = atomic_load_explicit(&(ptr->a), order);
     }
-    if (pointer == __RAW_UNMANAGED_NULL) { return (void*) pointer; }
+    // return immediately if pointer is NULL (importantly: without locking)
+    if (pointer == __RAW_UNMANAGED_NULL) { return NULL; }
   } while(!atomic_compare_exchange_weak_explicit(&(ptr->a), &pointer, action, order, order));
 
   return (void*) pointer;

--- a/Tests/AtomicsTests/ReferenceTests.swift
+++ b/Tests/AtomicsTests/ReferenceTests.swift
@@ -38,9 +38,10 @@ public class ReferenceTests: XCTestCase
     XCTAssert(a.swap(nil) != nil)
 
     i = UInt.randomPositive()
-    XCTAssert(a.swapIfNil(Thing(i)) == true)
+    XCTAssert(a.storeIfNil(Thing(i)) == true)
     let j = UInt.randomPositive()
     print("Will drop    \(j)")
+    // a compiler warning is expected for the next line
     XCTAssert(a.swapIfNil(Thing(j)) == false)
 
     print("Will release \(i)")

--- a/Tests/AtomicsTests/ReferenceTests.swift
+++ b/Tests/AtomicsTests/ReferenceTests.swift
@@ -30,6 +30,7 @@ public class ReferenceTests: XCTestCase
       let r1 = a.swap(.none)
       print("Will release \(i)")
       XCTAssert(r1 != nil)
+      XCTAssert(a.load() == nil)
     }
 
     i = UInt.randomPositive()
@@ -43,6 +44,11 @@ public class ReferenceTests: XCTestCase
     print("Will drop    \(j)")
     // a compiler warning is expected for the next line
     XCTAssert(a.swapIfNil(Thing(j)) == false)
+
+    do {
+      let v = a.load()
+      XCTAssert(v?.id == i)
+    }
 
     print("Will release \(i)")
     XCTAssert(a.take() != nil)

--- a/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
@@ -11,13 +11,18 @@ import Dispatch
 
 import CAtomics
 
-private struct Point { var x = 0.0, y = 0.0, z = 0.0 }
+private enum TestError: Error { case value(UInt) }
 
 private class Thing
 {
   let id: UInt
-  init(_ x: UInt = UInt.randomPositive()) { id = x }
-  deinit { print("Released     \(id)") }
+  init(_ x: UInt) { id = x }
+}
+
+private class Witness: Thing
+{
+  override init(_ x: UInt) { super.init(x) }
+  deinit { print("Released  \(id)") }
 }
 
 public class UnmanagedTests: XCTestCase
@@ -25,27 +30,27 @@ public class UnmanagedTests: XCTestCase
   public func testUnmanaged()
   {
     var i = UInt.randomPositive()
-    var u = Unmanaged.passRetained(Thing(i))
+    var u = Unmanaged.passRetained(Witness(i))
     var a = RawUnmanaged()
     a.initialize(u.toOpaque())
     do {
       let p = a.spinSwap(nil, .relaxed)
-      print("Will release \(i)")
+      print("Releasing \(i)")
       XCTAssert(p != nil)
-      let r = p.map { Unmanaged<Thing>.fromOpaque($0).takeRetainedValue() }
+      let r = p.map(Unmanaged<Witness>.fromOpaque)?.takeRetainedValue()
       XCTAssert(r != nil)
     }
 
     i = UInt.randomPositive()
-    u = Unmanaged.passRetained(Thing(i))
+    u = Unmanaged.passRetained(Witness(i))
     XCTAssert(a.spinSwap(u.toOpaque(), .release) == nil)
-    print("Releasing    \(i)")
+    print("Releasing \(i)")
     let p = a.spinSwap(nil, .acquire)
     XCTAssert(p != nil)
-    _ = p.map { Unmanaged<Thing>.fromOpaque($0).takeRetainedValue() }
+    _ = p.map(Unmanaged<Witness>.fromOpaque)?.takeRetainedValue()
 
     i = UInt.randomPositive()
-    u = Unmanaged.passRetained(Thing(i))
+    u = Unmanaged.passRetained(Witness(i))
     XCTAssert(a.safeStore(u.toOpaque(), .release) == true)
     XCTAssert(a.safeStore(u.toOpaque(), .relaxed) == false)
 
@@ -54,8 +59,153 @@ public class UnmanagedTests: XCTestCase
     XCTAssert(v == UnsafeRawPointer(u.toOpaque()))
     XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
     a.rawStore(nil, .release)
-    print("Releasing    \(i)")
-    v.map { Unmanaged<Thing>.fromOpaque($0).release() }
+    print("Releasing \(i)")
+    v.map(Unmanaged<Witness>.fromOpaque)?.release()
+  }
+
+  public func testSpinLoad()
+  {
+    let i = UInt.randomPositive()
+    var a = RawUnmanaged()
+    a.initialize(Unmanaged.passRetained(Thing(i)).toOpaque())
+
+    let p = a.spinLoad(.lock, .relaxed)
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+
+    let e = expectation(description: "swap-to-nil after unlock")
+    DispatchQueue.global().async {
+      if let p = a.spinLoad(.lock, .relaxed)
+      {
+        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+        XCTAssert(t.id == i)
+        e.fulfill()
+      }
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { a.rawStore(p, .release) })
+    waitForExpectations(timeout: 0.2)
+
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+  }
+
+  public func testSpinTake()
+  {
+    let i = UInt.randomPositive()
+    var a = RawUnmanaged()
+    a.initialize(Unmanaged.passRetained(Thing(i)).toOpaque())
+
+    let p = a.spinLoad(.lock, .relaxed)
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+
+    let e = expectation(description: "load-and-lock after unlock")
+    DispatchQueue.global().async {
+      if let p = a.spinLoad(.null, .relaxed)
+      {
+        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+        XCTAssert(t.id == i)
+        e.fulfill()
+      }
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { a.rawStore(p, .release) })
+    waitForExpectations(timeout: 0.2)
+
+    XCTAssert(a.rawLoad(.relaxed) == nil)
+  }
+
+  public func testSpinSwap() throws
+  {
+    let i = UInt.randomPositive()
+    var a = RawUnmanaged()
+    a.initialize(Unmanaged.passRetained(Thing(i)).toOpaque())
+
+    let p = a.spinLoad(.lock, .relaxed)
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+
+    let j = UInt.randomPositive()
+    let e = expectation(description: "arbitrary swap after unlock")
+    DispatchQueue.global().async {
+      if let p = a.spinSwap(Unmanaged.passRetained(Thing(j)).toOpaque(), .relaxed)
+      {
+        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+        XCTAssert(t.id == i)
+        e.fulfill()
+      }
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { a.rawStore(p, .release) })
+    waitForExpectations(timeout: 0.2)
+
+    XCTAssert(a.rawLoad(.relaxed) != nil)
+    if let p = a.rawLoad(.relaxed)
+    {
+      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+      XCTAssert(t.id == j)
+    }
+    else { throw TestError.value(j) }
+  }
+
+  public func testSafeStoreSuccess() throws
+  {
+    let i = UInt.randomPositive()
+    var a = RawUnmanaged()
+    a.initialize(Unmanaged.passRetained(Thing(i)).toOpaque())
+
+    let p = a.spinLoad(.lock, .relaxed)
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+
+    let j = UInt.randomPositive()
+    let e = expectation(description: "succeed at swapping for nil")
+    DispatchQueue.global().async {
+      let stored = a.safeStore(Unmanaged.passRetained(Thing(j)).toOpaque(), .relaxed)
+      XCTAssert(stored)
+      e.fulfill()
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { a.rawStore(nil, .release) })
+    waitForExpectations(timeout: 0.2)
+
+    XCTAssert(a.rawLoad(.relaxed) != nil)
+    if let p = a.rawLoad(.relaxed)
+    {
+      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+      XCTAssert(t.id == j)
+    }
+    else { throw TestError.value(j) }
+    if let p = p
+    {
+      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+      XCTAssert(t.id == i)
+    }
+    else { throw TestError.value(i) }
+  }
+
+  public func testSafeStoreFailure() throws
+  {
+    let i = UInt.randomPositive()
+    var a = RawUnmanaged()
+    a.initialize(Unmanaged.passRetained(Thing(i)).toOpaque())
+
+    let p = a.spinLoad(.lock, .relaxed)
+    XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
+
+    let e = expectation(description: "failure to swap for nil")
+    DispatchQueue.global().async {
+      let stored = a.safeStore(nil, .relaxed)
+      XCTAssert(!stored)
+      e.fulfill()
+    }
+
+    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { a.rawStore(p, .release) })
+    waitForExpectations(timeout: 0.2)
+
+    XCTAssert(a.rawLoad(.relaxed) != nil)
+    if let p = a.rawLoad(.relaxed)
+    {
+      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
+      XCTAssert(t.id == i)
+    }
+    else { throw TestError.value(i) }
   }
 }
 

--- a/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
@@ -53,7 +53,7 @@ public class UnmanagedTests: XCTestCase
     XCTAssert(v != nil)
     XCTAssert(v == UnsafeRawPointer(u.toOpaque()))
     XCTAssert(a.rawLoad(.relaxed) == UnsafeRawPointer(bitPattern: 0x7))
-    a.rawStore(nil, .relaxed)
+    a.rawStore(nil, .release)
     print("Releasing    \(i)")
     v.map { Unmanaged<Thing>.fromOpaque($0).release() }
   }

--- a/Tests/CAtomicsTests/XCTestManifests.swift
+++ b/Tests/CAtomicsTests/XCTestManifests.swift
@@ -44,6 +44,11 @@ extension UnmanagedRaceTests {
 
 extension UnmanagedTests {
     static let __allTests = [
+        ("testSafeStoreFailure", testSafeStoreFailure),
+        ("testSafeStoreSuccess", testSafeStoreSuccess),
+        ("testSpinLoad", testSpinLoad),
+        ("testSpinSwap", testSpinSwap),
+        ("testSpinTake", testSpinTake),
         ("testUnmanaged", testUnmanaged),
     ]
 }

--- a/Tests/CAtomicsTests/XCTestManifests.swift
+++ b/Tests/CAtomicsTests/XCTestManifests.swift
@@ -44,6 +44,7 @@ extension UnmanagedRaceTests {
 
 extension UnmanagedTests {
     static let __allTests = [
+        ("testDemonstrateWhyLockIsNecessary", testDemonstrateWhyLockIsNecessary),
         ("testSafeStoreFailure", testSafeStoreFailure),
         ("testSafeStoreSuccess", testSafeStoreSuccess),
         ("testSpinLoad", testSpinLoad),


### PR DESCRIPTION
Said load() operation is not atomic, given that the reference must be protected while its reference count is incremented; if it were not, it would be possible for the reference count to go to zero from another thread's intervention before the count gets incremented. Therefore, there is a short critical section during which the reference is locked. The other operations are compatible with this new load() operation (i.e. they will wait when necessary), but still do their business in one atomic operation.