### PR TITLE
Initializers

### DIFF
--- a/Sources/Atomics/atomics-integer.swift
+++ b/Sources/Atomics/atomics-integer.swift
@@ -16,12 +16,6 @@
 
 extension AtomicInt
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Int) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Int {
     @inlinable
@@ -217,12 +211,6 @@ extension AtomicInt
 
 extension AtomicUInt
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: UInt) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: UInt {
     @inlinable
@@ -418,12 +406,6 @@ extension AtomicUInt
 
 extension AtomicInt8
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Int8) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int8)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Int8 {
     @inlinable
@@ -619,12 +601,6 @@ extension AtomicInt8
 
 extension AtomicUInt8
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: UInt8) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt8)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: UInt8 {
     @inlinable
@@ -820,12 +796,6 @@ extension AtomicUInt8
 
 extension AtomicInt16
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Int16) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int16)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Int16 {
     @inlinable
@@ -1021,12 +991,6 @@ extension AtomicInt16
 
 extension AtomicUInt16
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: UInt16) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt16)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: UInt16 {
     @inlinable
@@ -1222,12 +1186,6 @@ extension AtomicUInt16
 
 extension AtomicInt32
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Int32) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int32)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Int32 {
     @inlinable
@@ -1423,12 +1381,6 @@ extension AtomicInt32
 
 extension AtomicUInt32
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: UInt32) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt32)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: UInt32 {
     @inlinable
@@ -1624,12 +1576,6 @@ extension AtomicUInt32
 
 extension AtomicInt64
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Int64) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Int64)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Int64 {
     @inlinable
@@ -1825,12 +1771,6 @@ extension AtomicInt64
 
 extension AtomicUInt64
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: UInt64) after the default initializer, as long as the instance is unshared")
-  public init(_ value: UInt64)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: UInt64 {
     @inlinable
@@ -2026,12 +1966,6 @@ extension AtomicUInt64
 
 extension AtomicBool
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: Bool) after the default initializer, as long as the instance is unshared")
-  public init(_ value: Bool)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: Bool {
     @inlinable

--- a/Sources/Atomics/atomics-integer.swift.gyb
+++ b/Sources/Atomics/atomics-integer.swift.gyb
@@ -18,12 +18,6 @@
 
 extension ${AtomicType}
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ value: ${IntType}) after the default initializer, as long as the instance is unshared")
-  public init(_ value: ${IntType})
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var value: ${IntType} {
     @inlinable

--- a/Sources/Atomics/atomics-pointer.swift
+++ b/Sources/Atomics/atomics-pointer.swift
@@ -22,7 +22,7 @@ public struct AtomicNonNullPointer<Pointee>
 
   public init(_ pointer: UnsafePointer<Pointee>)
   {
-    self.initialize(pointer)
+    ptr.initialize(UnsafeRawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: UnsafePointer<Pointee>)
@@ -143,7 +143,7 @@ public struct AtomicNonNullMutablePointer<Pointee>
 
   public init(_ pointer: UnsafeMutablePointer<Pointee>)
   {
-    self.initialize(pointer)
+    ptr.initialize(UnsafeMutableRawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: UnsafeMutablePointer<Pointee>)
@@ -262,11 +262,14 @@ public struct AtomicOptionalPointer<Pointee>
   @_versioned var ptr = AtomicOptionalRawPointer()
 #endif
 
-  public init() { }
+  public init()
+  {
+    ptr.initialize(nil)
+  }
 
   public init(_ pointer: UnsafePointer<Pointee>?)
   {
-    self.initialize(pointer)
+    ptr.initialize(UnsafeRawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: UnsafePointer<Pointee>?)
@@ -385,11 +388,14 @@ public struct AtomicOptionalMutablePointer<Pointee>
   @_versioned var ptr = AtomicOptionalMutableRawPointer()
 #endif
 
-  public init() { }
+  public init()
+  {
+    ptr.initialize(nil)
+  }
 
   public init(_ pointer: UnsafeMutablePointer<Pointee>?)
   {
-    self.initialize(pointer)
+    ptr.initialize(UnsafeMutableRawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: UnsafeMutablePointer<Pointee>?)
@@ -504,12 +510,6 @@ public struct AtomicOptionalMutablePointer<Pointee>
 
 extension AtomicNonNullRawPointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeRawPointer) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeRawPointer)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: UnsafeRawPointer {
     @inlinable
@@ -613,12 +613,6 @@ extension AtomicNonNullRawPointer
 
 extension AtomicOptionalRawPointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeRawPointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeRawPointer?)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: UnsafeRawPointer? {
     @inlinable
@@ -722,12 +716,6 @@ extension AtomicOptionalRawPointer
 
 extension AtomicNonNullMutableRawPointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeMutableRawPointer) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeMutableRawPointer)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: UnsafeMutableRawPointer {
     @inlinable
@@ -831,12 +819,6 @@ extension AtomicNonNullMutableRawPointer
 
 extension AtomicOptionalMutableRawPointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: UnsafeMutableRawPointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: UnsafeMutableRawPointer?)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: UnsafeMutableRawPointer? {
     @inlinable
@@ -940,12 +922,6 @@ extension AtomicOptionalMutableRawPointer
 
 extension AtomicNonNullOpaquePointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: OpaquePointer) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: OpaquePointer)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: OpaquePointer {
     @inlinable
@@ -1049,12 +1025,6 @@ extension AtomicNonNullOpaquePointer
 
 extension AtomicOptionalOpaquePointer
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: OpaquePointer?) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: OpaquePointer?)
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: OpaquePointer? {
     @inlinable

--- a/Sources/Atomics/atomics-pointer.swift.gyb
+++ b/Sources/Atomics/atomics-pointer.swift.gyb
@@ -25,12 +25,15 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
 #endif
 
 % if Nullable == 'Optional':
-  public init() { }
+  public init()
+  {
+    ptr.initialize(nil)
+  }
 
 % end
   public init(_ pointer: Unsafe${Mutable}${Pointer})
   {
-    self.initialize(pointer)
+    ptr.initialize(Unsafe${Mutable}RawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: Unsafe${Mutable}${Pointer})
@@ -148,12 +151,6 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
 
 extension ${AtomicType}
 {
-  @available(*, unavailable, message: "If needed, use initialize(_ pointer: ${PointerType}) after the default initializer, as long as the instance is unshared")
-  public init(_ pointer: ${PointerType})
-  {
-    self.init()
-  }
-
 #if swift(>=4.2)
   public var pointer: ${PointerType} {
     @inlinable

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -95,11 +95,17 @@ SWIFT_ENUM(CASType, closed)
 #define CLANG_ATOMICS_STRUCT(swiftType, atomicType, alignment) \
         typedef struct { _Alignas(alignment) volatile atomicType a; } swiftType;
 
-#define CLANG_ATOMICS_INIT(swiftType, parameterType) \
+#define CLANG_ATOMICS_INITIALIZE(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(swiftType.initialize(self:_:)) \
-        void swiftType##Init(swiftType *_Nonnull ptr, parameterType value) \
+        void swiftType##Initialize(swiftType *_Nonnull ptr, parameterType value) \
         { atomic_init(&(ptr->a), value); }
+
+#define CLANG_ATOMICS_CREATE(swiftType, parameterType) \
+        static __inline__ __attribute__((__always_inline__)) \
+        SWIFT_NAME(swiftType.init(_:)) \
+        swiftType swiftType##Create(parameterType value) \
+        { swiftType s; swiftType##Initialize(&s, value); return s; }
 
 #define CLANG_ATOMICS_LOAD(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
@@ -149,7 +155,8 @@ SWIFT_ENUM(CASType, closed)
 
 #define CLANG_ATOMICS_GENERATE(swiftType, atomicType, parameterType, alignment) \
         CLANG_ATOMICS_STRUCT(swiftType, atomicType, alignment) \
-        CLANG_ATOMICS_INIT(swiftType, parameterType) \
+        CLANG_ATOMICS_INITIALIZE(swiftType, parameterType) \
+        CLANG_ATOMICS_CREATE(swiftType, parameterType) \
         CLANG_ATOMICS_LOAD(swiftType, parameterType) \
         CLANG_ATOMICS_STORE(swiftType, parameterType) \
         CLANG_ATOMICS_SWAP(swiftType, parameterType) \
@@ -198,11 +205,17 @@ CLANG_ATOMICS_BOOL_GENERATE(AtomicCacheLineAlignedBool, atomic_bool, _Bool, __CA
 
 // pointer atomics
 
-#define CLANG_ATOMICS_POINTER_INIT(swiftType, parameterType, nullability) \
+#define CLANG_ATOMICS_POINTER_INITIALIZE(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(swiftType.initialize(self:_:)) \
-        void swiftType##Init(swiftType *_Nonnull ptr, parameterType nullability value) \
+        void swiftType##Initialize(swiftType *_Nonnull ptr, parameterType nullability value) \
         { atomic_init(&(ptr->a), (uintptr_t)value); }
+
+#define CLANG_ATOMICS_POINTER_CREATE(swiftType, parameterType, nullability) \
+        static __inline__ __attribute__((__always_inline__)) \
+        SWIFT_NAME(swiftType.init(_:)) \
+        swiftType swiftType##Create(parameterType nullability value) \
+        { swiftType s; swiftType##Initialize(&s, value); return s; }
 
 #define CLANG_ATOMICS_POINTER_LOAD(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
@@ -246,7 +259,8 @@ CLANG_ATOMICS_BOOL_GENERATE(AtomicCacheLineAlignedBool, atomic_bool, _Bool, __CA
 
 #define CLANG_ATOMICS_POINTER_GENERATE(swiftType, atomicType, parameterType, nullability, alignment) \
         CLANG_ATOMICS_STRUCT(swiftType, atomicType, alignment) \
-        CLANG_ATOMICS_POINTER_INIT(swiftType, parameterType, nullability) \
+        CLANG_ATOMICS_POINTER_INITIALIZE(swiftType, parameterType, nullability) \
+        CLANG_ATOMICS_POINTER_CREATE(swiftType, parameterType, nullability) \
         CLANG_ATOMICS_POINTER_LOAD(swiftType, parameterType, nullability) \
         CLANG_ATOMICS_POINTER_STORE(swiftType, parameterType, nullability) \
         CLANG_ATOMICS_POINTER_SWAP(swiftType, parameterType, nullability) \

--- a/Tests/AtomicsTests/AtomicsTests.swift
+++ b/Tests/AtomicsTests/AtomicsTests.swift
@@ -14,8 +14,7 @@ public class AtomicsBasicTests: XCTestCase
 {
   public func testInt()
   {
-    var i = AtomicInt()
-    i.initialize(0)
+    var i = AtomicInt(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -80,8 +79,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testUInt()
   {
-    var i = AtomicUInt()
-    i.initialize(0)
+    var i = AtomicUInt(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -146,8 +144,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testInt8()
   {
-    var i = AtomicInt8()
-    i.initialize(0)
+    var i = AtomicInt8(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -212,8 +209,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testUInt8()
   {
-    var i = AtomicUInt8()
-    i.initialize(0)
+    var i = AtomicUInt8(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -278,8 +274,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testInt16()
   {
-    var i = AtomicInt16()
-    i.initialize(0)
+    var i = AtomicInt16(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -344,8 +339,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testUInt16()
   {
-    var i = AtomicUInt16()
-    i.initialize(0)
+    var i = AtomicUInt16(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -410,8 +404,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testInt32()
   {
-    var i = AtomicInt32()
-    i.initialize(0)
+    var i = AtomicInt32(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -476,8 +469,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testUInt32()
   {
-    var i = AtomicUInt32()
-    i.initialize(0)
+    var i = AtomicUInt32(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -542,8 +534,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testInt64()
   {
-    var i = AtomicInt64()
-    i.initialize(0)
+    var i = AtomicInt64(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -608,8 +599,7 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testUInt64()
   {
-    var i = AtomicUInt64()
-    i.initialize(0)
+    var i = AtomicUInt64(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -674,15 +664,19 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testOptionalUnsafeRawPointer()
   {
-    var i = AtomicOptionalRawPointer()
-    XCTAssert(i.pointer == nil)
+    var n = AtomicOptionalRawPointer()
+    XCTAssertEqual(n.pointer, nil)
 
+    let r0 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
     let r1 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
     let r2 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
 
+    var i = AtomicOptionalRawPointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -702,16 +696,15 @@ public class AtomicsBasicTests: XCTestCase
   public func testNonNullUnsafeRawPointer()
   {
     let r0 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
-    var i = AtomicNonNullRawPointer()
-    i.initialize(r0)
-    XCTAssert(i.pointer == r0)
-
     let r1 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
     let r2 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
 
+    var i = AtomicNonNullRawPointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -730,15 +723,19 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testOptionalUnsafeMutableRawPointer()
   {
-    var i = AtomicOptionalMutableRawPointer()
-    XCTAssert(i.pointer == nil)
+    var n = AtomicOptionalMutableRawPointer()
+    XCTAssertEqual(n.pointer, nil)
 
+    let r0 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
     let r1 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
     let r2 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
 
+    var i = AtomicOptionalMutableRawPointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -758,16 +755,15 @@ public class AtomicsBasicTests: XCTestCase
   public func testNonNullUnsafeMutableRawPointer()
   {
     let r0 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
-    var i = AtomicNonNullMutableRawPointer()
-    i.initialize(r0)
-    XCTAssert(i.pointer == r0)
-
     let r1 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
     let r2 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
 
+    var i = AtomicNonNullMutableRawPointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -786,15 +782,19 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testOptionalUnsafePointer()
   {
-    var i = AtomicOptionalPointer<Int64>()
-    XCTAssert(i.pointer == nil)
+    var n = AtomicOptionalPointer<Int64>()
+    XCTAssertEqual(n.pointer, nil)
 
+    let r0 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())
     let r1 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())
     let r2 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())
     let r3 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())
 
+    var i = AtomicOptionalPointer<Int64>(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -814,15 +814,15 @@ public class AtomicsBasicTests: XCTestCase
   public func testNonNullUnsafePointer()
   {
     let r0 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())!
-    var i = AtomicNonNullPointer<Int64>(r0)
-    XCTAssert(i.pointer == r0)
-
     let r1 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())!
     let r2 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())!
     let r3 = UnsafePointer<Int64>(bitPattern: UInt.randomPositive())!
 
+    var i = AtomicNonNullPointer<Int64>(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -841,15 +841,19 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testOptionalUnsafeMutablePointer()
   {
-    var i = AtomicOptionalMutablePointer<Int64>()
-    XCTAssert(i.pointer == nil)
+    var n = AtomicOptionalMutablePointer<Int64>()
+    XCTAssertEqual(n.pointer, nil)
 
+    let r0 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())
     let r1 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())
     let r2 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())
     let r3 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())
 
+    var i = AtomicOptionalMutablePointer<Int64>(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -869,15 +873,15 @@ public class AtomicsBasicTests: XCTestCase
   public func testNonNullUnsafeMutablePointer()
   {
     let r0 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())!
-    var i = AtomicNonNullMutablePointer<Int64>(r0)
-    XCTAssert(i.pointer == r0)
-
     let r1 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())!
     let r2 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())!
     let r3 = UnsafeMutablePointer<Int64>(bitPattern: UInt.randomPositive())!
 
+    var i = AtomicNonNullMutablePointer<Int64>(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -896,15 +900,19 @@ public class AtomicsBasicTests: XCTestCase
 
   public func testOptionalOpaquePointer()
   {
-    var i = AtomicOptionalOpaquePointer()
-    XCTAssert(i.pointer == nil)
+    var n = AtomicOptionalOpaquePointer()
+    XCTAssertEqual(n.pointer, nil)
 
+    let r0 = OpaquePointer(bitPattern: UInt.randomPositive())
     let r1 = OpaquePointer(bitPattern: UInt.randomPositive())
     let r2 = OpaquePointer(bitPattern: UInt.randomPositive())
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())
 
+    var i = AtomicOptionalOpaquePointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)
@@ -924,16 +932,15 @@ public class AtomicsBasicTests: XCTestCase
   public func testNonNullOpaquePointer()
   {
     let r0 = OpaquePointer(bitPattern: UInt.randomPositive())!
-    var i = AtomicNonNullOpaquePointer()
-    i.initialize(r0)
-    XCTAssert(i.pointer == r0)
-
     let r1 = OpaquePointer(bitPattern: UInt.randomPositive())!
     let r2 = OpaquePointer(bitPattern: UInt.randomPositive())!
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())!
 
+    var i = AtomicNonNullOpaquePointer(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)

--- a/Tests/AtomicsTests/AtomicsTests.swift.gyb
+++ b/Tests/AtomicsTests/AtomicsTests.swift.gyb
@@ -17,8 +17,7 @@ public class AtomicsBasicTests: XCTestCase
 % for i in integers:
   public func test${i}()
   {
-    var i = Atomic${i}()
-    i.initialize(0)
+    var i = Atomic${i}(0)
     XCTAssert(i.value == 0)
 
 #if swift(>=4.0)
@@ -91,26 +90,21 @@ public class AtomicsBasicTests: XCTestCase
   public func test${nullability}${unsafe}${p}Pointer()
   {
 % if optional == True:
-    var i = Atomic${nullability}${p}Pointer${pointee}()
-    XCTAssert(i.pointer == nil)
-% else:
-    let r0 = ${unsafe}${p}Pointer${pointee}(bitPattern: UInt.randomPositive())!
-% if pointee == '':
-    var i = Atomic${nullability}${p}Pointer${pointee}()
-    i.initialize(r0)
-% else:
-    var i = Atomic${nullability}${p}Pointer${pointee}(r0)
-% end
-    XCTAssert(i.pointer == r0)
-% end
+    var n = Atomic${nullability}${p}Pointer${pointee}()
+    XCTAssertEqual(n.pointer, nil)
 
+% end
 % bang = '' if optional else '!'
+    let r0 = ${unsafe}${p}Pointer${pointee}(bitPattern: UInt.randomPositive())${bang}
     let r1 = ${unsafe}${p}Pointer${pointee}(bitPattern: UInt.randomPositive())${bang}
     let r2 = ${unsafe}${p}Pointer${pointee}(bitPattern: UInt.randomPositive())${bang}
     let r3 = ${unsafe}${p}Pointer${pointee}(bitPattern: UInt.randomPositive())${bang}
 
+    var i = Atomic${nullability}${p}Pointer${pointee}(r0)
+    XCTAssertEqual(i.pointer, r0)
+
     i.store(r1)
-    XCTAssert(r1 == i.load())
+    XCTAssertEqual(r1, i.load())
 
     var j = i.swap(r2)
     XCTAssertEqual(r1, j)

--- a/Tests/CAtomicsTests/CAtomicsTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift
@@ -599,7 +599,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
 
-    var p = AtomicOptionalRawPointer()
+    var p = AtomicOptionalRawPointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -629,7 +631,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
 
-    var p = AtomicNonNullRawPointer()
+    var p = AtomicNonNullRawPointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -659,7 +663,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
 
-    var p = AtomicOptionalMutableRawPointer()
+    var p = AtomicOptionalMutableRawPointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -689,7 +695,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
 
-    var p = AtomicNonNullMutableRawPointer()
+    var p = AtomicNonNullMutableRawPointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -719,7 +727,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = OpaquePointer(bitPattern: UInt.randomPositive())
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())
 
-    var p = AtomicOptionalOpaquePointer()
+    var p = AtomicOptionalOpaquePointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -749,7 +759,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = OpaquePointer(bitPattern: UInt.randomPositive())!
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())!
 
-    var p = AtomicNonNullOpaquePointer()
+    var p = AtomicNonNullOpaquePointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -829,4 +841,3 @@ public class CAtomicsBasicTests: XCTestCase
     CAtomicsThreadFence(.acquire)
   }
 }
-

--- a/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
@@ -87,7 +87,9 @@ public class CAtomicsBasicTests: XCTestCase
     let r2 = ${native}Pointer(bitPattern: UInt.randomPositive())${bang}
     let r3 = ${native}Pointer(bitPattern: UInt.randomPositive())${bang}
 
-    var p = Atomic${nullable}${type}Pointer()
+    var p = Atomic${nullable}${type}Pointer(r3)
+    XCTAssertEqual(r3, p.load(.relaxed))
+
     p.initialize(r0)
     XCTAssertEqual(r0, p.load(.relaxed))
 
@@ -169,4 +171,3 @@ public class CAtomicsBasicTests: XCTestCase
     CAtomicsThreadFence(.acquire)
   }
 }
-


### PR DESCRIPTION
Initialize atomic types with non-zero values
- this is nice for the pointer wrappers that don't deal with nullable pointers