### PR TITLE
Make reference fully atomic

### DIFF
--- a/Tests/AtomicsTests/ReferenceTests.swift
+++ b/Tests/AtomicsTests/ReferenceTests.swift
@@ -28,13 +28,10 @@ public class ReferenceTests: XCTestCase
         let thing2 = Thing(UInt.randomPositive())
         let originalRetainCount = CFGetRetainCount(thing1)
         
-        var a = AtomicReference<Thing>()
-        _ = a.storeIfNil(thing1)
-        var currentRetainCount = CFGetRetainCount(thing1)
-        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
+        var a = AtomicReference(thing1)
         
         _ = a.storeIfNil(thing2)
-        currentRetainCount = CFGetRetainCount(thing1)
+        var currentRetainCount = CFGetRetainCount(thing1)
         XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
         currentRetainCount = CFGetRetainCount(thing2)
         XCTAssertEqual(currentRetainCount, originalRetainCount)
@@ -51,13 +48,19 @@ public class ReferenceTests: XCTestCase
         currentRetainCount = CFGetRetainCount(thing2)
         XCTAssertEqual(currentRetainCount, originalRetainCount)
         
-        let thing1a = a.load()
+        _ = a.load()
         currentRetainCount = CFGetRetainCount(thing1)
-        XCTAssertEqual(currentRetainCount, originalRetainCount + 2)
-        currentRetainCount = CFGetRetainCount(thing1a)
-        XCTAssertEqual(currentRetainCount, originalRetainCount + 2)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
         currentRetainCount = CFGetRetainCount(thing2)
         XCTAssertEqual(currentRetainCount, originalRetainCount)
+    
+        _ = a.swap(nil)
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount)
+        
+        _ = a.storeIfNil(thing1)
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
     }
     
   public func testUnmanaged()

--- a/Tests/AtomicsTests/ReferenceTests.swift
+++ b/Tests/AtomicsTests/ReferenceTests.swift
@@ -22,6 +22,44 @@ private class Thing
 
 public class ReferenceTests: XCTestCase
 {
+    
+    public func testRetainCount() {
+        let thing1 = Thing(UInt.randomPositive())
+        let thing2 = Thing(UInt.randomPositive())
+        let originalRetainCount = CFGetRetainCount(thing1)
+        
+        var a = AtomicReference<Thing>()
+        _ = a.storeIfNil(thing1)
+        var currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
+        
+        _ = a.storeIfNil(thing2)
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
+        currentRetainCount = CFGetRetainCount(thing2)
+        XCTAssertEqual(currentRetainCount, originalRetainCount)
+        
+        _ = a.CAS(current: thing1, future: thing2)
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount)
+        currentRetainCount = CFGetRetainCount(thing2)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
+        
+        _ = a.swap(thing1)
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 1)
+        currentRetainCount = CFGetRetainCount(thing2)
+        XCTAssertEqual(currentRetainCount, originalRetainCount)
+        
+        let thing1a = a.load()
+        currentRetainCount = CFGetRetainCount(thing1)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 2)
+        currentRetainCount = CFGetRetainCount(thing1a)
+        XCTAssertEqual(currentRetainCount, originalRetainCount + 2)
+        currentRetainCount = CFGetRetainCount(thing2)
+        XCTAssertEqual(currentRetainCount, originalRetainCount)
+    }
+    
   public func testUnmanaged()
   {
     var i = UInt.randomPositive()

--- a/Tests/AtomicsTests/XCTestManifests.swift
+++ b/Tests/AtomicsTests/XCTestManifests.swift
@@ -45,6 +45,7 @@ extension ReferenceRaceTests {
 
 extension ReferenceTests {
     static let __allTests = [
+        ("testRetainCount", testRetainCount),
         ("testUnmanaged", testUnmanaged),
     ]
 }


### PR DESCRIPTION
Hi Guillaume,

I have worked a bit with AtomicReference and think came up with a solution that resolves this retain count problem you've explained me earlier. The idea is just that AtomicReference by default retains its pointee and releases it again once the pointer is changed. This way, another thread cannot kill a variable without the other thread knowing.

Note that this is WIP in that I didn't quite understand all the code. To be more precise, I didn't know what the assert in load is supposed to mean and why it's necessary. I assumed it was necessary because of the spin load but wanted to be sure anyways. Apart from that I wasn't a 100% sure about the semantics of the load method either, or at least I got a bit confused. I assume load is not supposed to delete the reference to the object right? Maybe you could clarify this assertion real quick.

I have also written a test to ensure AtomicReference correctly releases the references again. Let me know if you think any other tests are necessary.