### PR TITLE
Add Windows/LLP64 support

### DIFF
--- a/Sources/CAtomics/CAtomics.c
+++ b/Sources/CAtomics/CAtomics.c
@@ -6,7 +6,7 @@
 //  This file is distributed under the BSD 3-clause license. See LICENSE for details.
 //
 
-#import "CAtomics.h"
+#include "CAtomics.h"
 
 // See: http://clang.llvm.org/doxygen/stdatomic_8h_source.html
 //      http://clang.llvm.org/docs/LanguageExtensions.html#c11-atomic-builtins

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -187,8 +187,8 @@ SWIFT_ENUM(CASType, closed)
 
 // integer atomics
 
-CLANG_ATOMICS_INT_GENERATE(AtomicInt, atomic_long, long, _Alignof(atomic_long))
-CLANG_ATOMICS_INT_GENERATE(AtomicUInt, atomic_ulong, unsigned long, _Alignof(atomic_ulong))
+CLANG_ATOMICS_INT_GENERATE(AtomicInt, atomic_intptr_t, intptr_t, _Alignof(atomic_intptr_t))
+CLANG_ATOMICS_INT_GENERATE(AtomicUInt, atomic_uintptr_t, uintptr_t, _Alignof(atomic_uintptr_t))
 
 CLANG_ATOMICS_INT_GENERATE(AtomicInt8, atomic_schar, signed char, _Alignof(atomic_schar))
 CLANG_ATOMICS_INT_GENERATE(AtomicUInt8, atomic_uchar, unsigned char, _Alignof(atomic_uchar))
@@ -213,8 +213,8 @@ CLANG_ATOMICS_INT_GENERATE(AtomicUInt64, atomic_ullong, unsigned long long, _Ali
 CLANG_ATOMICS_BOOL_GENERATE(AtomicBool, atomic_bool, _Bool, _Alignof(atomic_bool))
 
 #ifdef __CACHE_LINE_WIDTH
-CLANG_ATOMICS_INT_GENERATE(AtomicCacheLineAlignedInt, atomic_long, long, __CACHE_LINE_WIDTH)
-CLANG_ATOMICS_INT_GENERATE(AtomicCacheLineAlignedUInt, atomic_ulong, unsigned long, __CACHE_LINE_WIDTH)
+CLANG_ATOMICS_INT_GENERATE(AtomicCacheLineAlignedInt, atomic_intptr_t, intptr_t, __CACHE_LINE_WIDTH)
+CLANG_ATOMICS_INT_GENERATE(AtomicCacheLineAlignedUInt, atomic_uintptr_t, uintptr_t, __CACHE_LINE_WIDTH)
 CLANG_ATOMICS_BOOL_GENERATE(AtomicCacheLineAlignedBool, atomic_bool, _Bool, __CACHE_LINE_WIDTH)
 #endif
 


### PR DESCRIPTION
On Windows x64, `long` and `unsigned long` are `Int32` and `UInt32` respectively. To ensure the `AtomicInt` types are imported consistently on all platforms, use `intptr_t` and `uintptr_t`, which are special-cased in https://github.com/apple/swift/blob/master/lib/ClangImporter/MappedTypes.def.

Also change an `#import` to an `#include` since `#import` means something different for Clang's Microsoft-compatible mode.