### PR TITLE
use overloadable function names rather than SWIFT_NAME attributes

### DIFF
--- a/Sources/Atomics/atomics-integer.swift
+++ b/Sources/Atomics/atomics-integer.swift
@@ -11,6 +11,7 @@
 @_exported import enum CAtomics.LoadMemoryOrder
 @_exported import enum CAtomics.StoreMemoryOrder
 @_exported import enum CAtomics.CASType
+import CAtomics
 
 @_exported import struct CAtomics.AtomicInt
 
@@ -19,12 +20,26 @@ extension AtomicInt
 #if swift(>=4.2)
   public var value: Int {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Int {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Int)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Int)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -32,13 +47,13 @@ extension AtomicInt
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -46,13 +61,13 @@ extension AtomicInt
   @inlinable
   public mutating func store(_ value: Int, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Int, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -60,13 +75,13 @@ extension AtomicInt
   @inlinable
   public mutating func swap(_ value: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -74,13 +89,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func add(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -88,13 +103,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func subtract(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -102,13 +117,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -116,13 +131,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -130,13 +145,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -144,13 +159,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -158,13 +173,13 @@ extension AtomicInt
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -175,7 +190,7 @@ extension AtomicInt
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -184,7 +199,7 @@ extension AtomicInt
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -194,7 +209,7 @@ extension AtomicInt
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -202,7 +217,7 @@ extension AtomicInt
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -214,12 +229,26 @@ extension AtomicUInt
 #if swift(>=4.2)
   public var value: UInt {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: UInt {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: UInt)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: UInt)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -227,13 +256,13 @@ extension AtomicUInt
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -241,13 +270,13 @@ extension AtomicUInt
   @inlinable
   public mutating func store(_ value: UInt, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: UInt, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -255,13 +284,13 @@ extension AtomicUInt
   @inlinable
   public mutating func swap(_ value: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -269,13 +298,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func add(_ delta: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -283,13 +312,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func subtract(_ delta: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -297,13 +326,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -311,13 +340,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -325,13 +354,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt, order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -339,13 +368,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -353,13 +382,13 @@ extension AtomicUInt
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -370,7 +399,7 @@ extension AtomicUInt
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -379,7 +408,7 @@ extension AtomicUInt
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -389,7 +418,7 @@ extension AtomicUInt
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -397,7 +426,7 @@ extension AtomicUInt
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -409,12 +438,26 @@ extension AtomicInt8
 #if swift(>=4.2)
   public var value: Int8 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Int8 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Int8)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Int8)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -422,13 +465,13 @@ extension AtomicInt8
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int8
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int8
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -436,13 +479,13 @@ extension AtomicInt8
   @inlinable
   public mutating func store(_ value: Int8, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Int8, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -450,13 +493,13 @@ extension AtomicInt8
   @inlinable
   public mutating func swap(_ value: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -464,13 +507,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func add(_ delta: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -478,13 +521,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func subtract(_ delta: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -492,13 +535,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -506,13 +549,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -520,13 +563,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int8, order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -534,13 +577,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -548,13 +591,13 @@ extension AtomicInt8
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int8
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -565,7 +608,7 @@ extension AtomicInt8
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -574,7 +617,7 @@ extension AtomicInt8
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -584,7 +627,7 @@ extension AtomicInt8
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -592,7 +635,7 @@ extension AtomicInt8
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -604,12 +647,26 @@ extension AtomicUInt8
 #if swift(>=4.2)
   public var value: UInt8 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: UInt8 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: UInt8)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: UInt8)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -617,13 +674,13 @@ extension AtomicUInt8
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt8
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt8
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -631,13 +688,13 @@ extension AtomicUInt8
   @inlinable
   public mutating func store(_ value: UInt8, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: UInt8, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -645,13 +702,13 @@ extension AtomicUInt8
   @inlinable
   public mutating func swap(_ value: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -659,13 +716,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func add(_ delta: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -673,13 +730,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func subtract(_ delta: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -687,13 +744,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -701,13 +758,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -715,13 +772,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt8, order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -729,13 +786,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -743,13 +800,13 @@ extension AtomicUInt8
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt8
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -760,7 +817,7 @@ extension AtomicUInt8
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -769,7 +826,7 @@ extension AtomicUInt8
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -779,7 +836,7 @@ extension AtomicUInt8
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -787,7 +844,7 @@ extension AtomicUInt8
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -799,12 +856,26 @@ extension AtomicInt16
 #if swift(>=4.2)
   public var value: Int16 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Int16 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Int16)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Int16)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -812,13 +883,13 @@ extension AtomicInt16
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int16
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int16
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -826,13 +897,13 @@ extension AtomicInt16
   @inlinable
   public mutating func store(_ value: Int16, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Int16, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -840,13 +911,13 @@ extension AtomicInt16
   @inlinable
   public mutating func swap(_ value: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -854,13 +925,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func add(_ delta: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -868,13 +939,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func subtract(_ delta: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -882,13 +953,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -896,13 +967,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -910,13 +981,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int16, order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -924,13 +995,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -938,13 +1009,13 @@ extension AtomicInt16
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int16
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -955,7 +1026,7 @@ extension AtomicInt16
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -964,7 +1035,7 @@ extension AtomicInt16
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -974,7 +1045,7 @@ extension AtomicInt16
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -982,7 +1053,7 @@ extension AtomicInt16
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -994,12 +1065,26 @@ extension AtomicUInt16
 #if swift(>=4.2)
   public var value: UInt16 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: UInt16 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: UInt16)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: UInt16)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1007,13 +1092,13 @@ extension AtomicUInt16
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt16
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt16
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1021,13 +1106,13 @@ extension AtomicUInt16
   @inlinable
   public mutating func store(_ value: UInt16, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: UInt16, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -1035,13 +1120,13 @@ extension AtomicUInt16
   @inlinable
   public mutating func swap(_ value: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -1049,13 +1134,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func add(_ delta: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -1063,13 +1148,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func subtract(_ delta: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -1077,13 +1162,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -1091,13 +1176,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -1105,13 +1190,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt16, order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -1119,13 +1204,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -1133,13 +1218,13 @@ extension AtomicUInt16
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt16
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -1150,7 +1235,7 @@ extension AtomicUInt16
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -1159,7 +1244,7 @@ extension AtomicUInt16
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -1169,7 +1254,7 @@ extension AtomicUInt16
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -1177,7 +1262,7 @@ extension AtomicUInt16
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -1189,12 +1274,26 @@ extension AtomicInt32
 #if swift(>=4.2)
   public var value: Int32 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Int32 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Int32)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Int32)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1202,13 +1301,13 @@ extension AtomicInt32
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int32
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int32
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1216,13 +1315,13 @@ extension AtomicInt32
   @inlinable
   public mutating func store(_ value: Int32, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Int32, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -1230,13 +1329,13 @@ extension AtomicInt32
   @inlinable
   public mutating func swap(_ value: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -1244,13 +1343,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func add(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -1258,13 +1357,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func subtract(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -1272,13 +1371,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -1286,13 +1385,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -1300,13 +1399,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -1314,13 +1413,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -1328,13 +1427,13 @@ extension AtomicInt32
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int32
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -1345,7 +1444,7 @@ extension AtomicInt32
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -1354,7 +1453,7 @@ extension AtomicInt32
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -1364,7 +1463,7 @@ extension AtomicInt32
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -1372,7 +1471,7 @@ extension AtomicInt32
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -1384,12 +1483,26 @@ extension AtomicUInt32
 #if swift(>=4.2)
   public var value: UInt32 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: UInt32 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: UInt32)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: UInt32)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1397,13 +1510,13 @@ extension AtomicUInt32
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt32
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt32
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1411,13 +1524,13 @@ extension AtomicUInt32
   @inlinable
   public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -1425,13 +1538,13 @@ extension AtomicUInt32
   @inlinable
   public mutating func swap(_ value: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -1439,13 +1552,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func add(_ delta: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -1453,13 +1566,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func subtract(_ delta: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -1467,13 +1580,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -1481,13 +1594,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -1495,13 +1608,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt32, order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -1509,13 +1622,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -1523,13 +1636,13 @@ extension AtomicUInt32
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt32
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -1540,7 +1653,7 @@ extension AtomicUInt32
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -1549,7 +1662,7 @@ extension AtomicUInt32
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -1559,7 +1672,7 @@ extension AtomicUInt32
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -1567,7 +1680,7 @@ extension AtomicUInt32
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -1579,12 +1692,26 @@ extension AtomicInt64
 #if swift(>=4.2)
   public var value: Int64 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Int64 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Int64)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Int64)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1592,13 +1719,13 @@ extension AtomicInt64
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int64
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Int64
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1606,13 +1733,13 @@ extension AtomicInt64
   @inlinable
   public mutating func store(_ value: Int64, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Int64, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -1620,13 +1747,13 @@ extension AtomicInt64
   @inlinable
   public mutating func swap(_ value: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -1634,13 +1761,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func add(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -1648,13 +1775,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func subtract(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -1662,13 +1789,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -1676,13 +1803,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -1690,13 +1817,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -1704,13 +1831,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -1718,13 +1845,13 @@ extension AtomicInt64
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> Int64
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -1735,7 +1862,7 @@ extension AtomicInt64
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -1744,7 +1871,7 @@ extension AtomicInt64
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -1754,7 +1881,7 @@ extension AtomicInt64
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -1762,7 +1889,7 @@ extension AtomicInt64
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -1774,12 +1901,26 @@ extension AtomicUInt64
 #if swift(>=4.2)
   public var value: UInt64 {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: UInt64 {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: UInt64)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: UInt64)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1787,13 +1928,13 @@ extension AtomicUInt64
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt64
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> UInt64
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1801,13 +1942,13 @@ extension AtomicUInt64
   @inlinable
   public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -1815,13 +1956,13 @@ extension AtomicUInt64
   @inlinable
   public mutating func swap(_ value: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -1829,13 +1970,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func add(_ delta: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_add(delta, order)
+    return CAtomicsAdd(&self, delta, order)
   }
 #endif
 
@@ -1843,13 +1984,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func subtract(_ delta: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_sub(delta, order)
+    return CAtomicsSubtract(&self, delta, order)
   }
 #endif
 
@@ -1857,13 +1998,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func bitwiseOr(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_or(bits, order)
+    return CAtomicsBitwiseOr(&self, bits, order)
   }
 #endif
 
@@ -1871,13 +2012,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func bitwiseXor(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_xor(bits, order)
+    return CAtomicsBitwiseXor(&self, bits, order)
   }
 #endif
 
@@ -1885,13 +2026,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt64, order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_and(bits, order)
+    return CAtomicsBitwiseAnd(&self, bits, order)
   }
 #endif
 
@@ -1899,13 +2040,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_add(1, order)
+    return CAtomicsAdd(&self, 1, order)
   }
 #endif
 
@@ -1913,13 +2054,13 @@ extension AtomicUInt64
   @inlinable @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .relaxed) -> UInt64
   {
-    return fetch_sub(1, order)
+    return CAtomicsSubtract(&self, 1, order)
   }
 #endif
 
@@ -1930,7 +2071,7 @@ extension AtomicUInt64
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -1939,7 +2080,7 @@ extension AtomicUInt64
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -1949,7 +2090,7 @@ extension AtomicUInt64
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -1957,7 +2098,7 @@ extension AtomicUInt64
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }
@@ -1969,12 +2110,26 @@ extension AtomicBool
 #if swift(>=4.2)
   public var value: Bool {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: Bool {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: Bool)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: Bool)
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -1982,13 +2137,13 @@ extension AtomicBool
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -1996,13 +2151,13 @@ extension AtomicBool
   @inlinable
   public mutating func store(_ value: Bool, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: Bool, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -2010,13 +2165,13 @@ extension AtomicBool
   @inlinable
   public mutating func swap(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
@@ -2024,13 +2179,13 @@ extension AtomicBool
   @inlinable @discardableResult
   public mutating func or(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_or(value, order)
+    return CAtomicsOr(&self, value, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func or(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_or(value, order)
+    return CAtomicsOr(&self, value, order)
   }
 #endif
 
@@ -2038,13 +2193,13 @@ extension AtomicBool
   @inlinable @discardableResult
   public mutating func xor(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_xor(value, order)
+    return CAtomicsXor(&self, value, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func xor(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_xor(value, order)
+    return CAtomicsXor(&self, value, order)
   }
 #endif
 
@@ -2052,13 +2207,13 @@ extension AtomicBool
   @inlinable @discardableResult
   public mutating func and(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_and(value, order)
+    return CAtomicsAnd(&self, value, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func and(_ value: Bool, order: MemoryOrder = .relaxed) -> Bool
   {
-    return fetch_and(value, order)
+    return CAtomicsAnd(&self, value, order)
   }
 #endif
 
@@ -2069,7 +2224,7 @@ extension AtomicBool
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -2078,7 +2233,7 @@ extension AtomicBool
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -2088,7 +2243,7 @@ extension AtomicBool
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -2096,7 +2251,7 @@ extension AtomicBool
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }

--- a/Sources/Atomics/atomics-integer.swift.gyb
+++ b/Sources/Atomics/atomics-integer.swift.gyb
@@ -11,6 +11,7 @@
 @_exported import enum CAtomics.LoadMemoryOrder
 @_exported import enum CAtomics.StoreMemoryOrder
 @_exported import enum CAtomics.CASType
+import CAtomics
 % for IntType in ['Int', 'UInt', 'Int8', 'UInt8', 'Int16', 'UInt16', 'Int32', 'UInt32', 'Int64', 'UInt64', 'Bool']:
 % AtomicType = 'Atomic' + IntType
 
@@ -21,12 +22,26 @@ extension ${AtomicType}
 #if swift(>=4.2)
   public var value: ${IntType} {
     @inlinable
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
 #else
   public var value: ${IntType} {
     @inline(__always)
-    mutating get { return load(.relaxed) }
+    mutating get { return CAtomicsLoad(&self, .relaxed) }
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
+  public mutating func initialize(_ value: ${IntType})
+  {
+    CAtomicsInitialize(&self, value)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ value: ${IntType})
+  {
+    CAtomicsInitialize(&self, value)
   }
 #endif
 
@@ -34,13 +49,13 @@ extension ${AtomicType}
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> ${IntType}
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .relaxed) -> ${IntType}
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -48,13 +63,13 @@ extension ${AtomicType}
   @inlinable
   public mutating func store(_ value: ${IntType}, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ value: ${IntType}, order: StoreMemoryOrder = .relaxed)
   {
-    store(value, order)
+    CAtomicsStore(&self, value, order)
   }
 #endif
 
@@ -62,62 +77,62 @@ extension ${AtomicType}
   @inlinable
   public mutating func swap(_ value: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ value: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return swap(value, order)
+    return CAtomicsExchange(&self, value, order)
   }
 #endif
 
 % if IntType == 'Bool':
-% for (rmwMethod, rmwFunc, rmwParam) in [('or', 'fetch_or', 'value'), ('xor', 'fetch_xor', 'value'), ('and', 'fetch_and', 'value')]:
+% for (rmwMethod, rmwFunc, rmwParam) in [('or', 'Or', 'value'), ('xor', 'Xor', 'value'), ('and', 'And', 'value')]:
 #if swift(>=4.2)
   @inlinable @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${rmwFunc}(${rmwParam}, order)
+    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${rmwFunc}(${rmwParam}, order)
+    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
 #endif
 
 % end # for
 % else:
-% for (rmwMethod, rmwFunc, rmwParam) in [('add', 'fetch_add', 'delta'), ('subtract', 'fetch_sub', 'delta'), ('bitwiseOr', 'fetch_or', 'bits'), ('bitwiseXor', 'fetch_xor', 'bits'), ('bitwiseAnd', 'fetch_and', 'bits')]:
+% for (rmwMethod, rmwFunc, rmwParam) in [('add', 'Add', 'delta'), ('subtract', 'Subtract', 'delta'), ('bitwiseOr', 'BitwiseOr', 'bits'), ('bitwiseXor', 'BitwiseXor', 'bits'), ('bitwiseAnd', 'BitwiseAnd', 'bits')]:
 #if swift(>=4.2)
   @inlinable @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${rmwFunc}(${rmwParam}, order)
+    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${rmwFunc}(${rmwParam}, order)
+    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
 #endif
 
 % end # for
-% for (inc, op) in [('increment', 'fetch_add'), ('decrement', 'fetch_sub')]:
+% for (inc, op) in [('increment', 'Add'), ('decrement', 'Subtract')]:
 #if swift(>=4.2)
   @inlinable @discardableResult
   public mutating func ${inc}(order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${op}(1, order)
+    return CAtomics${op}(&self, 1, order)
   }
 #else
   @inline(__always) @discardableResult
   public mutating func ${inc}(order: MemoryOrder = .relaxed) -> ${IntType}
   {
-    return ${op}(1, order)
+    return CAtomics${op}(&self, 1, order)
   }
 #endif
 
@@ -130,7 +145,7 @@ extension ${AtomicType}
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -139,7 +154,7 @@ extension ${AtomicType}
                                orderSwap: MemoryOrder = .relaxed,
                                orderLoad: LoadMemoryOrder = .relaxed) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -149,7 +164,7 @@ extension ${AtomicType}
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -157,7 +172,7 @@ extension ${AtomicType}
                            type: CASType = .strong,
                            order: MemoryOrder = .relaxed) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }

--- a/Sources/Atomics/atomics-pointer.swift.gyb
+++ b/Sources/Atomics/atomics-pointer.swift.gyb
@@ -11,6 +11,7 @@
 @_exported import enum CAtomics.LoadMemoryOrder
 @_exported import enum CAtomics.StoreMemoryOrder
 @_exported import enum CAtomics.CASType
+import CAtomics
 % for Nullable in ['NonNull', 'Optional']:
 % for Mutable in ['', 'Mutable']:
 % Pointer = 'Pointer<Pointee>?' if (Nullable == 'Optional') else 'Pointer<Pointee>'
@@ -27,32 +28,32 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
 % if Nullable == 'Optional':
   public init()
   {
-    ptr.initialize(nil)
+    CAtomicsInitialize(&ptr, nil)
   }
 
 % end
   public init(_ pointer: Unsafe${Mutable}${Pointer})
   {
-    ptr.initialize(Unsafe${Mutable}RawPointer(pointer))
+    CAtomicsInitialize(&ptr, Unsafe${Mutable}RawPointer(pointer))
   }
 
   public mutating func initialize(_ pointer: Unsafe${Mutable}${Pointer})
   {
-    ptr.initialize(Unsafe${Mutable}RawPointer(pointer))
+    CAtomicsInitialize(&ptr, Unsafe${Mutable}RawPointer(pointer))
   }
 
 #if swift(>=4.2)
   public var pointer: Unsafe${Mutable}${Pointer} {
     @inlinable
     mutating get {
-      return Unsafe${Mutable}Pointer<Pointee>(ptr.load(.relaxed)${optional}.assumingMemoryBound(to: Pointee.self))
+      return Unsafe${Mutable}Pointer<Pointee>(CAtomicsLoad(&ptr, .relaxed)${optional}.assumingMemoryBound(to: Pointee.self))
     }
   }
 #else
   public var pointer: Unsafe${Mutable}${Pointer} {
     @inline(__always)
     mutating get {
-      return Unsafe${Mutable}Pointer<Pointee>(ptr.load(.relaxed)${optional}.assumingMemoryBound(to: Pointee.self))
+      return Unsafe${Mutable}Pointer<Pointee>(CAtomicsLoad(&ptr, .relaxed)${optional}.assumingMemoryBound(to: Pointee.self))
     }
   }
 #endif
@@ -61,13 +62,13 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .sequential) -> Unsafe${Mutable}${Pointer}
   {
-    return Unsafe${Mutable}Pointer<Pointee>(ptr.load(order)${optional}.assumingMemoryBound(to: Pointee.self))
+    return Unsafe${Mutable}Pointer<Pointee>(CAtomicsLoad(&ptr, order)${optional}.assumingMemoryBound(to: Pointee.self))
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> Unsafe${Mutable}${Pointer}
   {
-    return Unsafe${Mutable}Pointer<Pointee>(ptr.load(order)${optional}.assumingMemoryBound(to: Pointee.self))
+    return Unsafe${Mutable}Pointer<Pointee>(CAtomicsLoad(&ptr, order)${optional}.assumingMemoryBound(to: Pointee.self))
   }
 #endif
 
@@ -75,13 +76,13 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
   @inlinable
   public mutating func store(_ pointer: Unsafe${Mutable}${Pointer}, order: StoreMemoryOrder = .sequential)
   {
-    ptr.store(Unsafe${Mutable}RawPointer(pointer), order)
+    CAtomicsStore(&ptr, Unsafe${Mutable}RawPointer(pointer), order)
   }
 #else
   @inline(__always)
   public mutating func store(_ pointer: Unsafe${Mutable}${Pointer}, order: StoreMemoryOrder = .sequential)
   {
-    ptr.store(Unsafe${Mutable}RawPointer(pointer), order)
+    CAtomicsStore(&ptr, Unsafe${Mutable}RawPointer(pointer), order)
   }
 #endif
 
@@ -89,13 +90,13 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
   @inlinable
   public mutating func swap(_ pointer: Unsafe${Mutable}${Pointer}, order: MemoryOrder = .sequential) -> Unsafe${Mutable}${Pointer}
   {
-    return Unsafe${Mutable}Pointer<Pointee>(ptr.swap(Unsafe${Mutable}RawPointer(pointer), order)${optional}.assumingMemoryBound(to: Pointee.self))
+    return Unsafe${Mutable}Pointer<Pointee>(CAtomicsExchange(&ptr, Unsafe${Mutable}RawPointer(pointer), order)${optional}.assumingMemoryBound(to: Pointee.self))
   }
 #else
   @inline(__always)
   public mutating func swap(_ pointer: Unsafe${Mutable}${Pointer}, order: MemoryOrder = .sequential) -> Unsafe${Mutable}${Pointer}
   {
-    return Unsafe${Mutable}Pointer<Pointee>(ptr.swap(Unsafe${Mutable}RawPointer(pointer), order)${optional}.assumingMemoryBound(to: Pointee.self))
+    return Unsafe${Mutable}Pointer<Pointee>(CAtomicsExchange(&ptr, Unsafe${Mutable}RawPointer(pointer), order)${optional}.assumingMemoryBound(to: Pointee.self))
   }
 #endif
 
@@ -108,7 +109,7 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
                                orderLoad: LoadMemoryOrder = .sequential) -> Bool
   {
     return current.withMemoryRebound(to: (Unsafe${Mutable}RawPointer${optional}).self, capacity: 1) {
-      ptr.loadCAS($0, Unsafe${Mutable}RawPointer(future), type, orderSwap, orderLoad)
+      CAtomicsCompareAndExchange(&ptr, $0, Unsafe${Mutable}RawPointer(future), type, orderSwap, orderLoad)
     }
   }
 #else
@@ -120,7 +121,7 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
                                orderLoad: LoadMemoryOrder = .sequential) -> Bool
   {
     return current.withMemoryRebound(to: (Unsafe${Mutable}RawPointer${optional}).self, capacity: 1) {
-      ptr.loadCAS($0, Unsafe${Mutable}RawPointer(future), type, orderSwap, orderLoad)
+      CAtomicsCompareAndExchange(&ptr, $0, Unsafe${Mutable}RawPointer(future), type, orderSwap, orderLoad)
     }
   }
 #endif
@@ -131,7 +132,7 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
                            type: CASType = .strong,
                            order: MemoryOrder = .sequential) -> Bool
   {
-    return ptr.CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&ptr, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -139,7 +140,7 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
                            type: CASType = .strong,
                            order: MemoryOrder = .sequential) -> Bool
   {
-    return ptr.CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&ptr, current, future, type, order)
   }
 #endif
 }
@@ -155,29 +156,43 @@ extension ${AtomicType}
   public var pointer: ${PointerType} {
     @inlinable
     mutating get {
-      return load(.relaxed)
+      return CAtomicsLoad(&self, .relaxed)
     }
   }
 #else
   public var pointer: ${PointerType} {
     @inline(__always)
     mutating get {
-      return load(.relaxed)
+      return CAtomicsLoad(&self, .relaxed)
     }
   }
 #endif
 
 #if swift(>=4.2)
   @inlinable
+  public mutating func initialize(_ pointer: ${PointerType})
+  {
+    CAtomicsInitialize(&self, pointer)
+  }
+#else
+  @inline(__always)
+  public mutating func initialize(_ pointer: ${PointerType})
+  {
+    CAtomicsInitialize(&self, pointer)
+  }
+#endif
+
+#if swift(>=4.2)
+  @inlinable
   public mutating func load(order: LoadMemoryOrder = .sequential) -> ${PointerType}
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #else
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> ${PointerType}
   {
-    return load(order)
+    return CAtomicsLoad(&self, order)
   }
 #endif
 
@@ -185,13 +200,13 @@ extension ${AtomicType}
   @inlinable
   public mutating func store(_ pointer: ${PointerType}, order: StoreMemoryOrder = .sequential)
   {
-    store(pointer, order)
+    CAtomicsStore(&self, pointer, order)
   }
 #else
   @inline(__always)
   public mutating func store(_ pointer: ${PointerType}, order: StoreMemoryOrder = .sequential)
   {
-    store(pointer, order)
+    CAtomicsStore(&self, pointer, order)
   }
 #endif
 
@@ -199,13 +214,13 @@ extension ${AtomicType}
   @inlinable
   public mutating func swap(_ pointer: ${PointerType}, order: MemoryOrder = .sequential) -> ${PointerType}
   {
-    return swap(pointer, order)
+    return CAtomicsExchange(&self, pointer, order)
   }
 #else
   @inline(__always)
   public mutating func swap(_ pointer: ${PointerType}, order: MemoryOrder = .sequential) -> ${PointerType}
   {
-    return swap(pointer, order)
+    return CAtomicsExchange(&self, pointer, order)
   }
 #endif
 
@@ -217,7 +232,7 @@ extension ${AtomicType}
                                orderSwap: MemoryOrder = .sequential,
                                orderLoad: LoadMemoryOrder = .sequential) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #else
   @inline(__always) @discardableResult
@@ -227,7 +242,7 @@ extension ${AtomicType}
                                orderSwap: MemoryOrder = .sequential,
                                orderLoad: LoadMemoryOrder = .sequential) -> Bool
   {
-    return loadCAS(current, future, type, orderSwap, orderLoad)
+    return CAtomicsCompareAndExchange(&self, current, future, type, orderSwap, orderLoad)
   }
 #endif
 
@@ -237,7 +252,7 @@ extension ${AtomicType}
                            type: CASType = .strong,
                            order: MemoryOrder = .sequential) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #else
   @inline(__always) @discardableResult
@@ -245,7 +260,7 @@ extension ${AtomicType}
                            type: CASType = .strong,
                            order: MemoryOrder = .sequential) -> Bool
   {
-    return CAS(current, future, type, order)
+    return CAtomicsCompareAndExchange(&self, current, future, type, order)
   }
 #endif
 }

--- a/Sources/Atomics/atomics-reference.swift
+++ b/Sources/Atomics/atomics-reference.swift
@@ -10,6 +10,7 @@
 @_exported import enum CAtomics.MemoryOrder
 @_exported import enum CAtomics.LoadMemoryOrder
 @_exported import enum CAtomics.StoreMemoryOrder
+import CAtomics
 
 import struct CAtomics.OpaqueUnmanagedHelper
 
@@ -45,7 +46,7 @@ public struct AtomicReference<T: AnyObject>
   mutating public func initialize(_ reference: T?)
   {
     let u = reference.map(Unmanaged.passRetained)
-    ptr.initialize(u?.toOpaque())
+    CAtomicsInitialize(&ptr, u?.toOpaque())
   }
 }
 
@@ -57,7 +58,7 @@ extension AtomicReference
   {
     let u = reference.map(Unmanaged.passRetained)?.toOpaque()
 
-    let pointer = ptr.spinSwap(u, order)
+    let pointer = CAtomicsExchange(&ptr, u, order)
     return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
   }
 #else
@@ -66,7 +67,7 @@ extension AtomicReference
   {
     let u = reference.map(Unmanaged.passRetained)?.toOpaque()
 
-    let pointer = ptr.spinSwap(u, order)
+    let pointer = CAtomicsExchange(&ptr, u, order)
     return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
   }
 #endif
@@ -88,7 +89,7 @@ extension AtomicReference
   public mutating func storeIfNil(_ reference: T, order: StoreMemoryOrder = .sequential) -> Bool
   {
     let u = Unmanaged.passUnretained(reference)
-    if ptr.CAS(nil, u.toOpaque(), .strong, MemoryOrder(rawValue: order.rawValue)!)
+    if CAtomicsCompareAndExchange(&ptr, nil, u.toOpaque(), .strong, MemoryOrder(rawValue: order.rawValue)!)
     {
       _ = u.retain()
       return true
@@ -100,7 +101,7 @@ extension AtomicReference
   public mutating func storeIfNil(_ reference: T, order: StoreMemoryOrder = .sequential) -> Bool
   {
     let u = Unmanaged.passUnretained(reference)
-    if ptr.CAS(nil, u.toOpaque(), .strong, MemoryOrder(rawValue: order.rawValue)!)
+    if CAtomicsCompareAndExchange(&ptr, nil, u.toOpaque(), .strong, MemoryOrder(rawValue: order.rawValue)!)
     {
       _ = u.retain()
       return true
@@ -112,7 +113,7 @@ extension AtomicReference
   public mutating func storeIfNil(_ reference: T, order: StoreMemoryOrder = .sequential) -> Bool
   {
     let u = Unmanaged.passUnretained(reference)
-    if ptr.CAS(nil, u.toOpaque(), .strong, MemoryOrder(order: order))
+    if CAtomicsCompareAndExchange(&ptr, nil, u.toOpaque(), .strong, MemoryOrder(order: order))
     {
       _ = u.retain()
       return true
@@ -125,21 +126,21 @@ extension AtomicReference
   @inlinable
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
-    let pointer = ptr.spinSwap(nil, MemoryOrder(rawValue: order.rawValue)!)
+    let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(rawValue: order.rawValue)!)
     return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
   }
 #elseif swift(>=3.2)
   @inline(__always)
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
-    let pointer = ptr.spinSwap(nil, MemoryOrder(rawValue: order.rawValue)!)
+    let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(rawValue: order.rawValue)!)
     return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
   }
 #else // swift 3.1
   @inline(__always)
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
-    let pointer = ptr.spinSwap(nil, MemoryOrder(order: order))
+    let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(order: order))
     return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
   }
 #endif
@@ -159,13 +160,13 @@ extension AtomicReference
   @inlinable
   public mutating func load(order: LoadMemoryOrder = .sequential) -> T?
   {
-    if let pointer = ptr.lockAndLoad(order)
+    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, order)
     {
-      assert(ptr.load(.sequential) == UnsafeRawPointer(bitPattern: 0x7))
+      assert(CAtomicsLoad(&ptr, .sequential) == UnsafeRawPointer(bitPattern: 0x7))
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()
       // ensure the reference counting operation has occurred before unlocking,
       // by performing our store operation with StoreMemoryOrder.release
-      ptr.store(pointer, .release)
+      CAtomicsStore(&ptr, pointer, .release)
       return unmanaged.takeRetainedValue()
     }
     return nil
@@ -185,13 +186,13 @@ extension AtomicReference
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .sequential) -> T?
   {
-    if let pointer = ptr.lockAndLoad(order)
+    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, order)
     {
-      assert(ptr.load(.sequential) == UnsafeRawPointer(bitPattern: 0x7))
+      assert(CAtomicsLoad(&ptr, .sequential) == UnsafeRawPointer(bitPattern: 0x7))
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()
       // ensure the reference counting operation has occurred before unlocking,
       // by performing our store operation with StoreMemoryOrder.release
-      ptr.store(pointer, .release)
+      CAtomicsStore(&ptr, pointer, .release)
       return unmanaged.takeRetainedValue()
     }
     return nil
@@ -199,39 +200,34 @@ extension AtomicReference
 #endif
     
 #if swift(>=4.2)
-    @inlinable
-    public mutating func CAS(current: T?, future: T?,
-                             type: CASType = .strong,
-                             order: MemoryOrder = .sequential) -> Bool
-    {
-        let cu = current.map { Unmanaged.passUnretained($0) }
-        let fu = future.map { Unmanaged.passUnretained($0) }
-        
-        let success = ptr.CAS(cu?.toOpaque(), fu?.toOpaque(), type, order)
-        if success {
-            _ = fu?.retain()
-            cu?.release()
-        }
-        
-        return success
-    }
-#else
-    @inline(__always) @discardableResult
-    public mutating func CAS(current: T?, future: T?,
-    type: CASType = .strong,
-    order: MemoryOrder = .sequential) -> Bool
-    {
-        let cu = current.map { Unmanaged.passUnretained($0) }
-        let fu = future.map { Unmanaged.passUnretained($0) }
-    
-        let success = ptr.CAS(cu?.toOpaque(), fu?.toOpaque(), type, order)
-        if success {
-            _ = fu?.retain()
-            cu?.release()
-        }
-    
-        return success
-    }
-#endif
+  @inlinable
+  public mutating func CAS(current: T?, future: T?,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .sequential) -> Bool
+  {
+    let c = current.map(Unmanaged.passUnretained)
+    let f = future.map(Unmanaged.passUnretained)
 
+    guard CAtomicsCompareAndExchange(&ptr, c?.toOpaque(), f?.toOpaque(), type, order)
+      else { return false }
+    _ = f?.retain()
+    c?.release()
+    return true
+  }
+#else
+  @inline(__always) @discardableResult
+  public mutating func CAS(current: T?, future: T?,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .sequential) -> Bool
+  {
+    let c = current.map(Unmanaged.passUnretained)
+    let f = future.map(Unmanaged.passUnretained)
+
+    guard CAtomicsCompareAndExchange(&ptr, c?.toOpaque(), f?.toOpaque(), type, order)
+      else { return false }
+    _ = f?.retain()
+    c?.release()
+    return true
+  }
+#endif
 }

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -105,51 +105,51 @@ SWIFT_ENUM(CASType, closed)
 
 #define CLANG_ATOMICS_IS_LOCK_FREE(swiftType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.isLockFree(self:)) \
-        _Bool swiftType##IsLockFree(swiftType *_Nonnull ptr) \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsIsLockFree(swiftType *_Nonnull ptr) \
         { return atomic_is_lock_free(&(ptr->a)); }
 
 #define CLANG_ATOMICS_INITIALIZE(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.initialize(self:_:)) \
-        void swiftType##Initialize(swiftType *_Nonnull ptr, parameterType value) \
+        __attribute__((overloadable)) \
+        void CAtomicsInitialize(swiftType *_Nonnull ptr, parameterType value) \
         { atomic_init(&(ptr->a), value); }
 
 #define CLANG_ATOMICS_CREATE(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(swiftType.init(_:)) \
         swiftType swiftType##Create(parameterType value) \
-        { swiftType s; swiftType##Initialize(&s, value); return s; }
+        { swiftType s; CAtomicsInitialize(&s, value); return s; }
 
 #define CLANG_ATOMICS_LOAD(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.load(self:_:)) \
-        parameterType swiftType##Load(swiftType *_Nonnull ptr, enum LoadMemoryOrder order) \
+        __attribute__((overloadable)) \
+        parameterType CAtomicsLoad(swiftType *_Nonnull ptr, enum LoadMemoryOrder order) \
         { return atomic_load_explicit(&(ptr->a), order); }
 
 #define CLANG_ATOMICS_STORE(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.store(self:_:_:)) \
-        void swiftType##Store(swiftType *_Nonnull ptr, parameterType value, enum StoreMemoryOrder order) \
+        __attribute__((overloadable)) \
+        void CAtomicsStore(swiftType *_Nonnull ptr, parameterType value, enum StoreMemoryOrder order) \
         { atomic_store_explicit(&(ptr->a), value, order); }
 
 #define CLANG_ATOMICS_SWAP(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.swap(self:_:_:)) \
-        parameterType swiftType##Swap(swiftType *_Nonnull ptr, parameterType value, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        parameterType CAtomicsExchange(swiftType *_Nonnull ptr, parameterType value, enum MemoryOrder order) \
         { return atomic_exchange_explicit(&(ptr->a), value, order); }
 
 #define CLANG_ATOMICS_RMW(swiftType, parameterType, pName, op, opName) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.op(self:_:_:)) \
-        parameterType swiftType##opName(swiftType *_Nonnull ptr, parameterType pName, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        parameterType CAtomics##opName(swiftType *_Nonnull ptr, parameterType pName, enum MemoryOrder order) \
         { return atomic_##op##_explicit(&(ptr->a), pName, order); }
 
 #define CLANG_ATOMICS_CAS(swiftType, parameterType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.loadCAS(self:_:_:_:_:_:)) \
-        _Bool swiftType##LoadCAS(swiftType *_Nonnull ptr, parameterType *_Nonnull current, parameterType future, \
-                                 enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(swiftType *_Nonnull ptr, parameterType *_Nonnull current, parameterType future, \
+                                         enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
           assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
           assert(orderSwap == __ATOMIC_RELEASE ? orderLoad == __ATOMIC_RELAXED : true); \
@@ -159,12 +159,12 @@ SWIFT_ENUM(CASType, closed)
             return atomic_compare_exchange_weak_explicit(&(ptr->a), current, future, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.CAS(self:_:_:_:_:)) \
-        _Bool swiftType##CAS(swiftType *_Nonnull ptr, parameterType current, parameterType future, \
-                             enum CASType type, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(swiftType *_Nonnull ptr, parameterType current, parameterType future, \
+                                         enum CASType type, enum MemoryOrder order) \
         { \
           parameterType expect = current; \
-          return swiftType##LoadCAS(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
+          return CAtomicsCompareAndExchange(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
         }
 
 #define CLANG_ATOMICS_GENERATE(swiftType, atomicType, parameterType, alignment) \
@@ -180,10 +180,10 @@ SWIFT_ENUM(CASType, closed)
 #define CLANG_ATOMICS_INT_GENERATE(swiftType, atomicType, parameterType, alignment) \
         CLANG_ATOMICS_GENERATE(swiftType, atomicType, parameterType, alignment) \
         CLANG_ATOMICS_RMW(swiftType, parameterType, increment, fetch_add, Add) \
-        CLANG_ATOMICS_RMW(swiftType, parameterType, increment, fetch_sub, Sub) \
-        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_or, Or) \
-        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_xor, Xor) \
-        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_and, And)
+        CLANG_ATOMICS_RMW(swiftType, parameterType, increment, fetch_sub, Subtract) \
+        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_or, BitwiseOr) \
+        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_xor, BitwiseXor) \
+        CLANG_ATOMICS_RMW(swiftType, parameterType, bits, fetch_and, BitwiseAnd)
 
 // integer atomics
 
@@ -222,38 +222,38 @@ CLANG_ATOMICS_BOOL_GENERATE(AtomicPaddedBool, atomic_bool, _Bool, __CACHE_LINE_W
 
 #define CLANG_ATOMICS_POINTER_INITIALIZE(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.initialize(self:_:)) \
-        void swiftType##Initialize(swiftType *_Nonnull ptr, parameterType nullability value) \
+        __attribute__((overloadable)) \
+        void CAtomicsInitialize(swiftType *_Nonnull ptr, parameterType nullability value) \
         { atomic_init(&(ptr->a), (uintptr_t)value); }
 
 #define CLANG_ATOMICS_POINTER_CREATE(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(swiftType.init(_:)) \
         swiftType swiftType##Create(parameterType nullability value) \
-        { swiftType s; swiftType##Initialize(&s, value); return s; }
+        { swiftType s; CAtomicsInitialize(&s, value); return s; }
 
 #define CLANG_ATOMICS_POINTER_LOAD(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.load(self:_:)) \
-        parameterType nullability swiftType##Load(swiftType *_Nonnull ptr, enum LoadMemoryOrder order) \
+        __attribute__((overloadable)) \
+        parameterType nullability CAtomicsLoad(swiftType *_Nonnull ptr, enum LoadMemoryOrder order) \
         { return (parameterType) atomic_load_explicit(&(ptr->a), order); }
 
 #define CLANG_ATOMICS_POINTER_STORE(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.store(self:_:_:)) \
-        void swiftType##Store(swiftType *_Nonnull ptr, parameterType nullability value, enum StoreMemoryOrder order) \
+        __attribute__((overloadable)) \
+        void CAtomicsStore(swiftType *_Nonnull ptr, parameterType nullability value, enum StoreMemoryOrder order) \
         { atomic_store_explicit(&(ptr->a), (uintptr_t)value, order); }
 
 #define CLANG_ATOMICS_POINTER_SWAP(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.swap(self:_:_:)) \
-        parameterType nullability swiftType##Swap(swiftType *_Nonnull ptr, parameterType nullability value, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        parameterType nullability CAtomicsExchange(swiftType *_Nonnull ptr, parameterType nullability value, enum MemoryOrder order) \
         { return (parameterType) atomic_exchange_explicit(&(ptr->a), (uintptr_t)value, order); }
 
 #define CLANG_ATOMICS_POINTER_CAS(swiftType, parameterType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.loadCAS(self:_:_:_:_:_:)) \
-        _Bool swiftType##LoadCAS(swiftType *_Nonnull ptr, parameterType nullability* _Nonnull current, parameterType nullability future, \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(swiftType *_Nonnull ptr, parameterType nullability* _Nonnull current, parameterType nullability future, \
                                  enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
           assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
@@ -264,12 +264,12 @@ CLANG_ATOMICS_BOOL_GENERATE(AtomicPaddedBool, atomic_bool, _Bool, __CACHE_LINE_W
             return atomic_compare_exchange_weak_explicit(&(ptr->a), (uintptr_t*)current, (uintptr_t)future, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(swiftType.CAS(self:_:_:_:_:)) \
-        _Bool swiftType##CAS(swiftType *_Nonnull ptr, parameterType nullability current, parameterType nullability future, \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(swiftType *_Nonnull ptr, parameterType nullability current, parameterType nullability future, \
                              enum CASType type, enum MemoryOrder order) \
         { \
           parameterType expect = current; \
-          return swiftType##LoadCAS(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
+          return CAtomicsCompareAndExchange(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
         }
 
 #define CLANG_ATOMICS_POINTER_GENERATE(swiftType, atomicType, parameterType, nullability, alignment) \
@@ -334,36 +334,36 @@ CLANG_ATOMICS_POINTER_GENERATE(AtomicOptionalOpaquePointer, atomic_uintptr_t, st
 
 #define CLANG_ATOMICS_TAGGED_POINTER_INITIALIZE(atomicType, structType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.initialize(self:_:)) \
-        void atomicType##Initialize(atomicType *_Nonnull ptr, structType value) \
+        __attribute__((overloadable)) \
+        void CAtomicsInitialize(atomicType *_Nonnull ptr, structType value) \
         { atomic_init(&(ptr->a), value.tag_ptr); } \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(atomicType.init(_:)) \
         atomicType atomicType##Create(structType value) \
-        { atomicType s; atomicType##Initialize(&s, value); return s; }
+        { atomicType s; CAtomicsInitialize(&s, value); return s; }
 
 #define CLANG_ATOMICS_TAGGED_POINTER_LOAD(atomicType, structType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.load(self:_:)) \
-        structType atomicType##Load(atomicType *_Nonnull ptr, enum LoadMemoryOrder order) \
+        __attribute__((overloadable)) \
+        structType CAtomicsLoad(atomicType *_Nonnull ptr, enum LoadMemoryOrder order) \
         { structType rp; rp.tag_ptr = atomic_load_explicit(&(ptr->a), order); return rp; }
 
 #define CLANG_ATOMICS_TAGGED_POINTER_STORE(atomicType, structType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.store(self:_:_:)) \
-        void atomicType##Store(atomicType *_Nonnull ptr, structType value, enum StoreMemoryOrder order) \
+        __attribute__((overloadable)) \
+        void CAtomicsStore(atomicType *_Nonnull ptr, structType value, enum StoreMemoryOrder order) \
         { atomic_store_explicit(&(ptr->a), value.tag_ptr, order); }
 
 #define CLANG_ATOMICS_TAGGED_POINTER_SWAP(atomicType, structType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.swap(self:_:_:)) \
-        structType atomicType##Swap(atomicType *_Nonnull ptr, structType value, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        structType CAtomicsExchange(atomicType *_Nonnull ptr, structType value, enum MemoryOrder order) \
         { structType rp; rp.tag_ptr = atomic_exchange_explicit(&(ptr->a), value.tag_ptr, order); return rp; }
 
 #define CLANG_ATOMICS_TAGGED_POINTER_CAS(atomicType, structType) \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.loadCAS(self:_:_:_:_:_:)) \
-        _Bool atomicType##LoadCAS(atomicType *_Nonnull ptr, structType *_Nonnull current, structType future, \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(atomicType *_Nonnull ptr, structType *_Nonnull current, structType future, \
                                          enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
           assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
@@ -374,12 +374,12 @@ CLANG_ATOMICS_POINTER_GENERATE(AtomicOptionalOpaquePointer, atomic_uintptr_t, st
             return atomic_compare_exchange_weak_explicit(&(ptr->a), &(current->tag_ptr), future.tag_ptr, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
-        SWIFT_NAME(atomicType.CAS(self:_:_:_:_:)) \
-        _Bool atomicType##CAS(atomicType *_Nonnull ptr, structType current, structType future, \
-                                     enum CASType type, enum MemoryOrder order) \
+        __attribute__((overloadable)) \
+        _Bool CAtomicsCompareAndExchange(atomicType *_Nonnull ptr, structType current, structType future, \
+                                         enum CASType type, enum MemoryOrder order) \
         { \
           structType expect = current; \
-          return atomicType##LoadCAS(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
+          return CAtomicsCompareAndExchange(ptr, &expect, future, type, order, LoadMemoryOrder_relaxed); \
         }
 
 #if defined(__has32bitPointer__)
@@ -461,8 +461,7 @@ CLANG_ATOMICS_POINTER_STORE(OpaqueUnmanagedHelper, const void*, _Nullable)
 CLANG_ATOMICS_POINTER_LOAD(OpaqueUnmanagedHelper, const void*, _Nullable)
 
 static __inline__ __attribute__((__always_inline__)) \
-SWIFT_NAME(OpaqueUnmanagedHelper.lockAndLoad(self:_:)) \
-const void *_Nullable UnmanagedLockAndLoad(OpaqueUnmanagedHelper *_Nonnull ptr, enum LoadMemoryOrder order)
+const void *_Nullable CAtomicsUnmanagedLockAndLoad(OpaqueUnmanagedHelper *_Nonnull ptr, enum LoadMemoryOrder order)
 { // load the pointer value, and leave the pointer either LOCKED or NULL; spin for the lock if necessary
 #ifndef __SSE2__
   char c;
@@ -489,8 +488,9 @@ const void *_Nullable UnmanagedLockAndLoad(OpaqueUnmanagedHelper *_Nonnull ptr, 
 }
 
 static __inline__ __attribute__((__always_inline__)) \
-SWIFT_NAME(OpaqueUnmanagedHelper.spinSwap(self:_:_:)) \
-const void *_Nullable UnmanagedSpinSwap(OpaqueUnmanagedHelper *_Nonnull ptr, const void *_Nullable value, enum MemoryOrder order)
+__attribute__((overloadable)) \
+const void *_Nullable CAtomicsExchange(OpaqueUnmanagedHelper *_Nonnull ptr,
+                                       const void *_Nullable value, enum MemoryOrder order)
 { // swap the pointer with `value`, spinning until the lock becomes unlocked if necessary
 #ifndef __SSE2__
   char c;
@@ -515,9 +515,10 @@ const void *_Nullable UnmanagedSpinSwap(OpaqueUnmanagedHelper *_Nonnull ptr, con
 }
 
 static __inline__ __attribute__((__always_inline__)) \
-SWIFT_NAME(OpaqueUnmanagedHelper.CAS(self:_:_:_:_:)) \
-_Bool UnmanagedCompareAndSwap(OpaqueUnmanagedHelper *_Nonnull ptr, const void *_Nullable current, const void *_Nullable future,
-                              enum CASType type, enum MemoryOrder order)
+__attribute__((overloadable)) \
+_Bool CAtomicsCompareAndExchange(OpaqueUnmanagedHelper *_Nonnull ptr,
+                                 const void *_Nullable current, const void *_Nullable future,
+                                 enum CASType type, enum MemoryOrder order)
 {
   if(type == __ATOMIC_CAS_TYPE_WEAK)
   {

--- a/Tests/AtomicsTests/AtomicsTests.swift
+++ b/Tests/AtomicsTests/AtomicsTests.swift
@@ -16,6 +16,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicInt(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = Int.randomPositive()
@@ -81,6 +83,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicUInt(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = UInt.randomPositive()
@@ -146,6 +150,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicInt8(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = Int8.randomPositive()
@@ -211,6 +217,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicUInt8(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = UInt8.randomPositive()
@@ -276,6 +284,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicInt16(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = Int16.randomPositive()
@@ -341,6 +351,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicUInt16(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = UInt16.randomPositive()
@@ -406,6 +418,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicInt32(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = Int32.randomPositive()
@@ -471,6 +485,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicUInt32(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = UInt32.randomPositive()
@@ -536,6 +552,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicInt64(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = Int64.randomPositive()
@@ -601,6 +619,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = AtomicUInt64(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = UInt64.randomPositive()
@@ -675,11 +695,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicOptionalRawPointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -703,11 +726,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicNonNullRawPointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -734,11 +760,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicOptionalMutableRawPointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -762,11 +791,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicNonNullMutableRawPointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -793,11 +825,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicOptionalPointer<Int64>(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -821,11 +856,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicNonNullPointer<Int64>(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -852,11 +890,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicOptionalMutablePointer<Int64>(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -880,11 +921,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicNonNullMutablePointer<Int64>(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -911,11 +955,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicOptionalOpaquePointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)
@@ -939,11 +986,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = AtomicNonNullOpaquePointer(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)

--- a/Tests/AtomicsTests/AtomicsTests.swift.gyb
+++ b/Tests/AtomicsTests/AtomicsTests.swift.gyb
@@ -19,6 +19,8 @@ public class AtomicsBasicTests: XCTestCase
   {
     var i = Atomic${i}(0)
     XCTAssert(i.value == 0)
+    i.initialize(1)
+    XCTAssert(i.value == 1)
 
 #if swift(>=4.0)
     let r1 = ${i}.randomPositive()
@@ -103,11 +105,14 @@ public class AtomicsBasicTests: XCTestCase
     var i = Atomic${nullability}${p}Pointer${pointee}(r0)
     XCTAssertEqual(i.pointer, r0)
 
-    i.store(r1)
-    XCTAssertEqual(r1, i.load())
+    i.initialize(r1)
+    XCTAssertEqual(i.pointer, r1)
+
+    i.store(r0)
+    XCTAssertEqual(r0, i.load())
 
     var j = i.swap(r2)
-    XCTAssertEqual(r1, j)
+    XCTAssertEqual(r0, j)
     XCTAssertEqual(r2, i.load())
 
     i.store(r1)

--- a/Tests/CAtomicsTests/CAtomicsTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift
@@ -15,9 +15,9 @@ public class CAtomicsBasicTests: XCTestCase
   public func testInt()
   {
     var i = AtomicInt()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = Int.randomPositive()
@@ -29,54 +29,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = Int(UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testUInt()
   {
     var i = AtomicUInt()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = UInt.randomPositive()
@@ -88,54 +88,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = UInt(UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testInt8()
   {
     var i = AtomicInt8()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = Int8.randomPositive()
@@ -147,54 +147,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = Int8(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testUInt8()
   {
     var i = AtomicUInt8()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = UInt8.randomPositive()
@@ -206,54 +206,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = UInt8(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testInt16()
   {
     var i = AtomicInt16()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = Int16.randomPositive()
@@ -265,54 +265,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = Int16(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testUInt16()
   {
     var i = AtomicUInt16()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = UInt16.randomPositive()
@@ -324,54 +324,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = UInt16(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testInt32()
   {
     var i = AtomicInt32()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = Int32.randomPositive()
@@ -383,54 +383,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = Int32(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testUInt32()
   {
     var i = AtomicUInt32()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = UInt32.randomPositive()
@@ -442,54 +442,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = UInt32(truncatingBitPattern: UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testInt64()
   {
     var i = AtomicInt64()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = Int64.randomPositive()
@@ -501,54 +501,54 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = Int64(UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testUInt64()
   {
     var i = AtomicUInt64()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = UInt64.randomPositive()
@@ -560,97 +560,97 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = UInt64(UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
   public func testBool()
   {
-    var boolean = AtomicBool()
-    boolean.initialize(false)
-    XCTAssert(boolean.load(.relaxed) == false)
-    XCTAssert(boolean.isLockFree())
+    var b = AtomicBool()
+    CAtomicsInitialize(&b, false)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    XCTAssert(CAtomicsIsLockFree(&b))
 
-    boolean.store(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
+    CAtomicsStore(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
 
-    boolean.store(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsStore(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    boolean.store(false, .relaxed)
-    boolean.fetch_or(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
-    boolean.fetch_or(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
-    boolean.store(false, .relaxed)
-    boolean.fetch_or(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_or(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsStore(&b, false, .relaxed)
+    CAtomicsOr(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
+    CAtomicsOr(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
+    CAtomicsStore(&b, false, .relaxed)
+    CAtomicsOr(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsOr(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    boolean.fetch_and(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_and(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
+    CAtomicsAnd(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsAnd(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
 
-    boolean.fetch_xor(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_xor(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsXor(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsXor(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    let old = boolean.swap(false, .relaxed)
+    let old = CAtomicsExchange(&b, false, .relaxed)
     XCTAssert(old == true)
-    XCTAssert(boolean.swap(true, .relaxed) == false)
+    XCTAssert(CAtomicsExchange(&b, true, .relaxed) == false)
 
     var current = true
-    XCTAssert(boolean.load(.relaxed) == current)
-    boolean.loadCAS(&current, false, .strong, .relaxed, .relaxed)
-    current = boolean.load(.relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == current)
+    CAtomicsCompareAndExchange(&b, &current, false, .strong, .relaxed, .relaxed)
+    current = CAtomicsLoad(&b, .relaxed)
     XCTAssert(current == false)
-    if boolean.loadCAS(&current, true, .strong, .relaxed, .relaxed)
+    if CAtomicsCompareAndExchange(&b, &current, true, .strong, .relaxed, .relaxed)
     {
       current = !current
-      XCTAssert(boolean.loadCAS(&current, false, .weak, .relaxed, .relaxed))
+      XCTAssert(CAtomicsCompareAndExchange(&b, &current, false, .weak, .relaxed, .relaxed))
       current = !current
-      XCTAssert(boolean.loadCAS(&current, true, .weak, .relaxed, .relaxed))
+      XCTAssert(CAtomicsCompareAndExchange(&b, &current, true, .weak, .relaxed, .relaxed))
     }
   }
 }
@@ -665,29 +665,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
 
     var p = AtomicOptionalRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicNonNullRawPointer()
@@ -698,29 +698,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
 
     var p = AtomicNonNullRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicNonNullMutableRawPointer()
@@ -731,29 +731,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
 
     var p = AtomicNonNullMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicOptionalMutableRawPointer()
@@ -764,29 +764,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
 
     var p = AtomicOptionalMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedMutableRawPointer()
@@ -797,29 +797,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())!
 
     var p = AtomicPaddedMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedOptionalMutableRawPointer()
@@ -830,29 +830,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeMutableRawPointer(bitPattern: UInt.randomPositive())
 
     var p = AtomicPaddedOptionalMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedRawPointer()
@@ -863,29 +863,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())!
 
     var p = AtomicPaddedRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedOptionalRawPointer()
@@ -896,29 +896,29 @@ extension CAtomicsBasicTests
     let r3 = UnsafeRawPointer(bitPattern: UInt.randomPositive())
 
     var p = AtomicPaddedOptionalRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicNonNullOpaquePointer()
@@ -929,29 +929,29 @@ extension CAtomicsBasicTests
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())!
 
     var p = AtomicNonNullOpaquePointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicOptionalOpaquePointer()
@@ -962,29 +962,29 @@ extension CAtomicsBasicTests
     let r3 = OpaquePointer(bitPattern: UInt.randomPositive())
 
     var p = AtomicOptionalOpaquePointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testFence()
@@ -1070,29 +1070,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicTaggedRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedTaggedRawPointer()
@@ -1103,29 +1103,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicPaddedTaggedRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testTaggedMutableRawPointer()
@@ -1167,29 +1167,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicTaggedMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedTaggedMutableRawPointer()
@@ -1200,29 +1200,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicPaddedTaggedMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testTaggedOptionalRawPointer()
@@ -1264,29 +1264,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicTaggedOptionalRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedTaggedOptionalRawPointer()
@@ -1297,29 +1297,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicPaddedTaggedOptionalRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testTaggedOptionalMutableRawPointer()
@@ -1361,29 +1361,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicTaggedOptionalMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testAtomicPaddedTaggedOptionalMutableRawPointer()
@@ -1394,29 +1394,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = AtomicPaddedTaggedOptionalMutableRawPointer(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
   public func testPaddedPointers()

--- a/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
@@ -17,9 +17,9 @@ public class CAtomicsBasicTests: XCTestCase
   public func test${i}()
   {
     var i = Atomic${i}()
-    i.initialize(0)
-    XCTAssertEqual(0, i.load(.relaxed))
-    XCTAssert(i.isLockFree())
+    CAtomicsInitialize(&i, 0)
+    XCTAssertEqual(0, CAtomicsLoad(&i, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&i))
 
 #if swift(>=4.0)
     let r1 = ${i}.randomPositive()
@@ -32,98 +32,98 @@ public class CAtomicsBasicTests: XCTestCase
     let r3 = ${i}(${truncating}UInt.randomPositive())
 #endif
 
-    i.store(r1, .relaxed)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    var j = i.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, i.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_add(r1, .relaxed)
+    j = CAtomicsAdd(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 &+ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 &+ r2, CAtomicsLoad(&i, .relaxed))
 
-    j = i.fetch_sub(r2, .relaxed)
+    j = CAtomicsSubtract(&i, r2, .relaxed)
     XCTAssertEqual(r1 &+ r2, j)
-    XCTAssertEqual(r1, i.load(.relaxed))
+    XCTAssertEqual(r1, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_or(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseOr(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 | r2, i.load(.relaxed))
+    XCTAssertEqual(r1 | r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r2, .relaxed)
-    j = i.fetch_xor(r1, .relaxed)
+    CAtomicsStore(&i, r2, .relaxed)
+    j = CAtomicsBitwiseXor(&i, r1, .relaxed)
     XCTAssertEqual(r2, j)
-    XCTAssertEqual(r1 ^ r2, i.load(.relaxed))
+    XCTAssertEqual(r1 ^ r2, CAtomicsLoad(&i, .relaxed))
 
-    i.store(r1, .relaxed)
-    j = i.fetch_and(r2, .relaxed)
+    CAtomicsStore(&i, r1, .relaxed)
+    j = CAtomicsBitwiseAnd(&i, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r1 & r2, i.load(.relaxed))
+    XCTAssertEqual(r1 & r2, CAtomicsLoad(&i, .relaxed))
 
     j = r1
-    i.store(r1, .relaxed)
-    XCTAssertTrue(i.loadCAS(&j, r2, .strong, .relaxed, .relaxed))
-    XCTAssertEqual(r2, i.load(.relaxed))
+    CAtomicsStore(&i, r1, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
-    i.store(r1, .relaxed)
-    while(!i.loadCAS(&j, r3, .weak, .relaxed, .relaxed)) {}
+    CAtomicsStore(&i, r1, .relaxed)
+    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, i.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
 
 % end
   public func testBool()
   {
-    var boolean = AtomicBool()
-    boolean.initialize(false)
-    XCTAssert(boolean.load(.relaxed) == false)
-    XCTAssert(boolean.isLockFree())
+    var b = AtomicBool()
+    CAtomicsInitialize(&b, false)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    XCTAssert(CAtomicsIsLockFree(&b))
 
-    boolean.store(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
+    CAtomicsStore(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
 
-    boolean.store(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsStore(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    boolean.store(false, .relaxed)
-    boolean.fetch_or(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
-    boolean.fetch_or(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
-    boolean.store(false, .relaxed)
-    boolean.fetch_or(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_or(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsStore(&b, false, .relaxed)
+    CAtomicsOr(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
+    CAtomicsOr(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
+    CAtomicsStore(&b, false, .relaxed)
+    CAtomicsOr(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsOr(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    boolean.fetch_and(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_and(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
+    CAtomicsAnd(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsAnd(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
 
-    boolean.fetch_xor(false, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == false)
-    boolean.fetch_xor(true, .relaxed)
-    XCTAssert(boolean.load(.relaxed) == true)
+    CAtomicsXor(&b, false, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == false)
+    CAtomicsXor(&b, true, .relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == true)
 
-    let old = boolean.swap(false, .relaxed)
+    let old = CAtomicsExchange(&b, false, .relaxed)
     XCTAssert(old == true)
-    XCTAssert(boolean.swap(true, .relaxed) == false)
+    XCTAssert(CAtomicsExchange(&b, true, .relaxed) == false)
 
     var current = true
-    XCTAssert(boolean.load(.relaxed) == current)
-    boolean.loadCAS(&current, false, .strong, .relaxed, .relaxed)
-    current = boolean.load(.relaxed)
+    XCTAssert(CAtomicsLoad(&b, .relaxed) == current)
+    CAtomicsCompareAndExchange(&b, &current, false, .strong, .relaxed, .relaxed)
+    current = CAtomicsLoad(&b, .relaxed)
     XCTAssert(current == false)
-    if boolean.loadCAS(&current, true, .strong, .relaxed, .relaxed)
+    if CAtomicsCompareAndExchange(&b, &current, true, .strong, .relaxed, .relaxed)
     {
       current = !current
-      XCTAssert(boolean.loadCAS(&current, false, .weak, .relaxed, .relaxed))
+      XCTAssert(CAtomicsCompareAndExchange(&b, &current, false, .weak, .relaxed, .relaxed))
       current = !current
-      XCTAssert(boolean.loadCAS(&current, true, .weak, .relaxed, .relaxed))
+      XCTAssert(CAtomicsCompareAndExchange(&b, &current, true, .weak, .relaxed, .relaxed))
     }
   }
 }
@@ -144,29 +144,29 @@ extension CAtomicsBasicTests
     let r3 = ${native}Pointer(bitPattern: UInt.randomPositive())${bang}
 
     var p = ${type}(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
 % end
@@ -256,29 +256,29 @@ extension CAtomicsBasicTests
     let r3 = r2.incremented()
 
     var p = ${atomicType}(r3)
-    XCTAssertEqual(r3, p.load(.relaxed))
-    XCTAssert(p.isLockFree())
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
+    XCTAssert(CAtomicsIsLockFree(&p))
 
-    p.initialize(r0)
-    XCTAssertEqual(r0, p.load(.relaxed))
+    CAtomicsInitialize(&p, r0)
+    XCTAssertEqual(r0, CAtomicsLoad(&p, .relaxed))
 
-    p.store(r1, .relaxed)
-    XCTAssertEqual(r1, p.load(.relaxed))
+    CAtomicsStore(&p, r1, .relaxed)
+    XCTAssertEqual(r1, CAtomicsLoad(&p, .relaxed))
 
-    var j = p.swap(r2, .relaxed)
+    var j = CAtomicsExchange(&p, r2, .relaxed)
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r2, p.load(.relaxed))
+    XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(p.CAS(r2, r3, .strong, .relaxed))
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(p.CAS(j, r2, .strong, .relaxed))
-    XCTAssertTrue(p.CAS(r3, r2, .strong, .relaxed))
-    j = p.load(.relaxed)
-    XCTAssertTrue(p.CAS(r2, r1, .strong, .relaxed))
-    while !p.loadCAS(&j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    j = CAtomicsLoad(&p, .relaxed)
+    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
+    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
-    XCTAssertEqual(r3, p.load(.relaxed))
+    XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
 
 % end


### PR DESCRIPTION
The swift-style names somehow cause the the thread sanitizer to never be happy with the C library, regardless of countermeasures taken. When using simple C-style function names, we can satisfy the thread sanitizer. Note that these are C-style function names with a twist, since they use the `overloadable` attribute of Clang.