### PR TITLE
probably fix `AtomicReference.load()`

### DIFF
--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -498,7 +498,7 @@ const void *_Nullable CAtomicsExchange(OpaqueUnmanagedHelper *_Nonnull atomic,
   c = 0;
 #endif
   uintptr_t pointer;
-  pointer = atomic_load_explicit(&(atomic->a), __ATOMIC_RELAXED);
+  pointer = atomic_load_explicit(&(atomic->a), order);
   do { // don't fruitlessly invalidate the cache line if the value is locked
     while (pointer == __OPAQUE_UNMANAGED_LOCKED)
     {
@@ -508,9 +508,9 @@ const void *_Nullable CAtomicsExchange(OpaqueUnmanagedHelper *_Nonnull atomic,
       c += 1;
       if ((c&__OPAQUE_UNMANAGED_SPINMASK) != 0) { sched_yield(); }
 #endif
-      pointer = atomic_load_explicit(&(atomic->a), __ATOMIC_RELAXED);
+      pointer = atomic_load_explicit(&(atomic->a), order);
     }
-  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, (uintptr_t)value, order, __ATOMIC_RELAXED));
+  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, (uintptr_t)value, order, order));
 
   return (void*) pointer;
 }

--- a/Sources/SwiftAtomics/atomics-reference.swift
+++ b/Sources/SwiftAtomics/atomics-reference.swift
@@ -156,9 +156,9 @@ extension AtomicReference
   /// the others operations will spin until a `load` operation is complete,
   /// but are otherwise atomic.
   @inlinable
-  public mutating func load(order: LoadMemoryOrder = .sequential) -> T?
+  public mutating func load() -> T?
   {
-    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, order)
+    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, .acquire)
     {
       assert(CAtomicsLoad(&ptr, .sequential) == UnsafeRawPointer(bitPattern: 0x7))
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()
@@ -182,9 +182,9 @@ extension AtomicReference
   /// the others operations will spin until a `load` operation is complete,
   /// but are otherwise atomic.
   @inline(__always)
-  public mutating func load(order: LoadMemoryOrder = .sequential) -> T?
+  public mutating func load() -> T?
   {
-    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, order)
+    if let pointer = CAtomicsUnmanagedLockAndLoad(&ptr, .acquire)
     {
       assert(CAtomicsLoad(&ptr, .sequential) == UnsafeRawPointer(bitPattern: 0x7))
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()

--- a/Sources/SwiftAtomics/atomics-reference.swift
+++ b/Sources/SwiftAtomics/atomics-reference.swift
@@ -44,8 +44,8 @@ public struct AtomicReference<T: AnyObject>
 
   mutating public func initialize(_ reference: T?)
   {
-    let u = reference.map(Unmanaged.passRetained)
-    CAtomicsInitialize(&ptr, u?.toOpaque())
+    let u = reference.map { Unmanaged.passRetained($0).toOpaque() }
+    CAtomicsInitialize(&ptr, u)
   }
 }
 
@@ -55,19 +55,19 @@ extension AtomicReference
   @inlinable
   public mutating func swap(_ reference: T?, order: MemoryOrder = .sequential) -> T?
   {
-    let u = reference.map(Unmanaged.passRetained)?.toOpaque()
+    let u = reference.map { Unmanaged.passRetained($0).toOpaque() }
 
     let pointer = CAtomicsExchange(&ptr, u, order)
-    return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
+    return pointer.map { Unmanaged.fromOpaque($0).takeRetainedValue() }
   }
 #else
   @inline(__always)
   public mutating func swap(_ reference: T?, order: MemoryOrder = .sequential) -> T?
   {
-    let u = reference.map(Unmanaged.passRetained)?.toOpaque()
+    let u = reference.map { Unmanaged.passRetained($0).toOpaque() }
 
     let pointer = CAtomicsExchange(&ptr, u, order)
-    return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
+    return pointer.map { Unmanaged.fromOpaque($0).takeRetainedValue() }
   }
 #endif
 
@@ -125,21 +125,21 @@ extension AtomicReference
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
     let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(rawValue: order.rawValue)!)
-    return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
+    return pointer.map { Unmanaged.fromOpaque($0).takeRetainedValue() }
   }
 #elseif swift(>=3.2)
   @inline(__always)
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
     let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(rawValue: order.rawValue)!)
-    return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
+    return pointer.map { Unmanaged.fromOpaque($0).takeRetainedValue() }
   }
 #else // swift 3.1
   @inline(__always)
   public mutating func take(order: LoadMemoryOrder = .sequential) -> T?
   {
     let pointer = CAtomicsExchange(&ptr, nil, MemoryOrder(order: order))
-    return pointer.map(Unmanaged.fromOpaque)?.takeRetainedValue()
+    return pointer.map { Unmanaged.fromOpaque($0).takeRetainedValue() }
   }
 #endif
 

--- a/Sources/SwiftAtomics/atomics-reference.swift
+++ b/Sources/SwiftAtomics/atomics-reference.swift
@@ -164,6 +164,7 @@ extension AtomicReference
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()
       // ensure the reference counting operation has occurred before unlocking,
       // by performing our store operation with StoreMemoryOrder.release
+      CAtomicsThreadFence(.release)
       CAtomicsStore(&ptr, pointer, .release)
       return unmanaged.takeRetainedValue()
     }
@@ -190,6 +191,7 @@ extension AtomicReference
       let unmanaged = Unmanaged<T>.fromOpaque(pointer).retain()
       // ensure the reference counting operation has occurred before unlocking,
       // by performing our store operation with StoreMemoryOrder.release
+      CAtomicsThreadFence(.release)
       CAtomicsStore(&ptr, pointer, .release)
       return unmanaged.takeRetainedValue()
     }

--- a/Tests/CAtomicsTests/XCTestManifests.swift
+++ b/Tests/CAtomicsTests/XCTestManifests.swift
@@ -59,6 +59,7 @@ extension MemoryOrderTests {
 extension UnmanagedRaceTests {
     static let __allTests = [
         ("testRaceAtomickishUnmanaged", testRaceAtomickishUnmanaged),
+        ("testRaceLoadVersusDeinit", testRaceLoadVersusDeinit),
     ]
 }
 

--- a/Tests/SwiftAtomicsTests/ReferenceTests.swift
+++ b/Tests/SwiftAtomicsTests/ReferenceTests.swift
@@ -141,8 +141,8 @@ public class ReferenceRaceTests: XCTestCase
 
     for _ in 1...iterations
     {
-      let b = ManagedBuffer<Int, Int>.create(minimumCapacity: 1, makingHeaderWith: { _ in 1 })
-      var r = AtomicReference(b)
+      var r = AtomicReference(ManagedBuffer<Int, Int>.create(minimumCapacity: 1, makingHeaderWith: { _ in 1 }))
+
       let closure = {
         while true
         {


### PR DESCRIPTION
On some versions of the compiler (Xcode 8.3.1, Swift 5.0 on macOS, perhaps others), there was an occasional use-after-free crash while running the test function `ReferenceRaceTests.testRaceLoadVersusDeinit()`. For some reason, this did not happen when using the Swift 4.2 compiler using which that solution was developed.

It seems that inserting a thread fence in between the reference counting operation and the unlocking operation of `AtomicReference.load()` prevents the problem from happening. While I'm unsure about the problem on Swift 3.1.1, on Swift 5 the fix probably prevents some inadvisable optimization from happening, and properly guarantees that the reference counting operation happens before the store operation that unlocks the reference.