### PR TITLE
remove `load()` on `AtomicReference`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: swift
 matrix:
   include:
     - os: osx
+      osx_image: xcode8.3
+      env: SWIFT=3.1.1
+
+    - os: osx
       osx_image: xcode9.2
       env: SWIFT=4.0.3
 
@@ -21,6 +25,11 @@ matrix:
     - os: osx
       osx_image: xcode11.2
       env: SWIFT=5.1.2
+
+    - os: linux
+      dist: xenial
+      language: generic
+      env: SWIFT=3.1.1
 
     - os: linux
       dist: xenial

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,8 @@
 
 import PackageDescription
 
+#if swift(>=4.0)
+
 let package = Package(
   name: "SwiftAtomics",
   products: [
@@ -16,3 +18,14 @@ let package = Package(
   ],
   swiftLanguageVersions: [.v3, .v4, .v4_2, .version("5")]
 )
+
+#else
+
+let package = Package(
+  name: "SwiftAtomics",
+  targets: [
+    Target(name: "SwiftAtomics", dependencies: ["CAtomics"]),
+  ]
+)
+
+#endif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # swift-atomics [![Build Status](https://travis-ci.org/glessard/swift-atomics.svg?branch=master)](https://travis-ci.org/glessard/swift-atomics)
-Some atomic functions made available to Swift 3.2 and up, thanks to Clang
+Some atomic functions made available to Swift 3.1 and up, thanks to Clang
 
 The atomic functions available in `/usr/include/libkern/OSAtomic.h` are quite limiting in Swift, due to impedance mismatches between the type systems of Swift and C. Furthermore, some simple things such as a synchronized load or a synchronized store are not immediately available. On top of that, they have now been deprecated.
 

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -456,6 +456,13 @@ __attribute__((overloadable)) \
 const void *_Nullable CAtomicsExchange(OpaqueUnmanagedHelper *_Nonnull atomic,
                                        const void *_Nullable value, enum MemoryOrder order)
 { // swap the pointer with `value`, spinning until the lock becomes unlocked if necessary
+  memory_order order_f;
+  switch(order)
+  {
+    case memory_order_acq_rel: order_f = memory_order_acquire;
+    case memory_order_release: order_f = memory_order_relaxed;
+    default:                   order_f = (memory_order)order;
+  }
 #ifndef __SSE2__
   char c;
   c = 0;
@@ -473,7 +480,7 @@ const void *_Nullable CAtomicsExchange(OpaqueUnmanagedHelper *_Nonnull atomic,
 #endif
       pointer = atomic_load_explicit(&(atomic->a), order);
     }
-  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, (uintptr_t)value, order, order));
+  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, (uintptr_t)value, order, order_f));
 
   return (void*) pointer;
 }

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -446,7 +446,7 @@ const void *_Nullable CAtomicsUnmanagedLockAndLoad(OpaqueUnmanagedHelper *_Nonnu
     }
     // return immediately if pointer is NULL (importantly: without locking)
     if (pointer == (uintptr_t) NULL) { return NULL; }
-  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, __OPAQUE_UNMANAGED_LOCKED, __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE));
+  } while(!atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, __OPAQUE_UNMANAGED_LOCKED, __ATOMIC_ACQUIRE, __ATOMIC_ACQUIRE));
 
   return (void*) pointer;
 }

--- a/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
@@ -55,11 +55,11 @@ public class UnmanagedTests: XCTestCase
     XCTAssertEqual(CAtomicsCompareAndExchange(&a, nil, u.toOpaque(), .strong, .release), true)
     XCTAssertEqual(CAtomicsCompareAndExchange(&a, nil, u.toOpaque(), .weak, .relaxed), false)
 
-    let v = CAtomicsUnmanagedLockAndLoad(&a)
+    let v = CAtomicsExchange(&a, nil, .acquire)
     XCTAssertNotNil(v)
     XCTAssertEqual(v, UnsafeRawPointer(u.toOpaque()))
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-    CAtomicsStore(&a, v, .release)
+    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), nil)
+    CAtomicsExchange(&a, v, .release)
 
     let j = UInt.randomPositive()
     u = Unmanaged.passRetained(Witness(j))
@@ -72,234 +72,13 @@ public class UnmanagedTests: XCTestCase
     u.release()
   }
 
-  public func testSpinLoad()
-  {
-    let i = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let e = expectation(description: "load and relock after unlock")
-    DispatchQueue.global().async {
-      if let p = CAtomicsUnmanagedLockAndLoad(&a)
-      {
-        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-        XCTAssertEqual(t.id, i)
-        e.fulfill()
-      }
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, p, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-  }
-
-  public func testSpinTake()
-  {
-    let i = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let e = expectation(description: "swap-to-nil after unlock")
-    DispatchQueue.global().async {
-      if let p = CAtomicsExchange(&a, nil, .relaxed)
-      {
-        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-        XCTAssertEqual(t.id, i)
-        e.fulfill()
-      }
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, p, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), nil)
-  }
-
-  public func testSpinSwap() throws
-  {
-    let i = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let j = UInt.randomPositive()
-    let e = expectation(description: "arbitrary swap after unlock")
-    DispatchQueue.global().async {
-      if let p = CAtomicsExchange(&a, Unmanaged.passRetained(Thing(j)).toOpaque(), .relaxed)
-      {
-        let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-        XCTAssertEqual(t.id, i)
-        e.fulfill()
-      }
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, p, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertNotNil(CAtomicsLoad(&a, .relaxed))
-    if let p = CAtomicsLoad(&a, .relaxed)
-    {
-      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-      XCTAssertEqual(t.id, j)
-    }
-    else { throw TestError.value(j) }
-  }
-
-  public func testStrongCASSuccess() throws
-  {
-    let i = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let j = UInt.randomPositive()
-    let e = expectation(description: "succeed at swapping for nil")
-    DispatchQueue.global().async {
-      let f = Unmanaged.passRetained(Thing(j)).toOpaque()
-      XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-      XCTAssertEqual(CAtomicsCompareAndExchange(&a, nil, f, .strong, .relaxed), true)
-      XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(f))
-      e.fulfill()
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, nil, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertNotNil(CAtomicsLoad(&a, .relaxed))
-    if let p = CAtomicsLoad(&a, .relaxed)
-    {
-      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-      XCTAssertEqual(t.id, j)
-    }
-    else { throw TestError.value(j) }
-    if let p = p
-    {
-      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-      XCTAssertEqual(t.id, i)
-    }
-    else { throw TestError.value(i) }
-  }
-
-  public func testStrongCASFailure() throws
-  {
-    let i = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let t = Thing(0)
-    let e = expectation(description: "failure to swap for nil")
-    DispatchQueue.global().async {
-      let f = Unmanaged.passUnretained(t).toOpaque()
-      XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-      XCTAssertEqual(CAtomicsCompareAndExchange(&a, nil, f, .strong, .relaxed), false)
-      XCTAssertNotEqual(CAtomicsLoad(&a, .relaxed), nil)
-      e.fulfill()
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, p, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertNotNil(CAtomicsLoad(&a, .relaxed))
-    if let p = CAtomicsLoad(&a, .relaxed)
-    {
-      let t = Unmanaged<Thing>.fromOpaque(p).takeRetainedValue()
-      XCTAssertEqual(t.id, i)
-    }
-    else { throw TestError.value(i) }
-  }
-
-  public func testWeakCasBlocked() throws
-  {
-    let i = UInt.randomPositive()
-    let j = UInt.randomPositive()
-    var a = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&a, Unmanaged.passRetained(Thing(i)).toOpaque())
-
-    let p = CAtomicsUnmanagedLockAndLoad(&a)
-    XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-
-    let e = expectation(description: "succeed at weak CAS")
-    DispatchQueue.global().async {
-      let f = Unmanaged.passRetained(Thing(j)).toOpaque()
-      XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(bitPattern: 0x7))
-      while !CAtomicsCompareAndExchange(&a, p, f, .weak, .sequential) {}
-      XCTAssertEqual(CAtomicsLoad(&a, .relaxed), UnsafeRawPointer(f))
-      e.fulfill()
-    }
-
-    DispatchQueue.global().asyncAfter(deadline: .now()+0.1, execute: { CAtomicsStore(&a, p, .release) })
-    waitForExpectations(timeout: 10.0)
-
-    XCTAssertNotNil(CAtomicsExchange(&a, nil, .acquire))
-    XCTAssertNil(CAtomicsLoad(&a, .relaxed))
-  }
-
-  public func testDemonstrateWhyLockIsNecessary() throws
-  {
-    let i = UInt.randomPositive()
-
-    var atomic = OpaqueUnmanagedHelper()
-    CAtomicsInitialize(&atomic, Unmanaged.passRetained(Witness(i)).toOpaque())
-
-    // this is a weird simulation of two threads racing to interact
-    // with an object stored in an "atomic reference".
-    // mock thread A wants to read the value stored in the object.
-    // mock thread B decrements the object's reference count.
-
-    // mock thread A needs a copy of the reference
-    guard let pointerA = CAtomicsLoad(&atomic, .acquire)
-      else { throw TestError.value(0) }
-    // mock thread A is interrupted
-
-    // mock thread B resumes execution
-    guard let pointerB = CAtomicsExchange(&atomic, nil, .acquire)
-      else { throw TestError.value(1) }
-
-    print("Releasing \(i)")
-    Unmanaged<Witness>.fromOpaque(pointerB).release()
-    // mock thread B is done
-
-    XCTAssertNil(CAtomicsLoad(&atomic, .relaxed))
-    XCTAssertEqual(pointerA, pointerB)
-
-    // mock thread A resumes execution
-    // it does not know (and has no way to know)
-    // that the object has been released.
-    let u = Unmanaged<Witness>.fromOpaque(pointerA)
-    _ = u
-    // when un-commented, the next line causes a use-after-free error
-    // let w = u.takeRetainedValue()
-    // print("Reading   \(w.id)")
-
-    // the following causes an immediate use-after-free crash
-    // u.release()
-
-    // this is similar to the Swift 2 runtime bug
-    // https://bugs.swift.org/browse/SR-192
-    // the only way to fix that -- short of a redesign --
-    // was to lock weak references while being copied.
-  }
 }
 
 private let iterations = 200_000//_000
 
 public class UnmanagedRaceTests: XCTestCase
 {
-  public func testRaceAtomickishUnmanaged()
+  public func testRaceAtomicUnmanaged()
   {
     let q = DispatchQueue(label: "", attributes: .concurrent)
 
@@ -322,7 +101,7 @@ public class UnmanagedRaceTests: XCTestCase
           }
           else
           {
-            XCTAssertNil(CAtomicsLoad(&r, .relaxed))
+            XCTAssertNil(CAtomicsExchange(&r,nil, .relaxed))
             break
           }
         }
@@ -333,67 +112,5 @@ public class UnmanagedRaceTests: XCTestCase
     }
 
     q.sync(flags: .barrier) {}
-  }
-
-  public func testRaceLoadVersusDeinit()
-  {
-    let q = DispatchQueue(label: "", attributes: .concurrent)
-
-    for _ in 1...iterations
-    {
-      let a = UnsafeMutablePointer<OpaqueUnmanagedHelper>.allocate(capacity: 1)
-      CAtomicsInitialize(a, Unmanaged.passRetained(Thing(.randomPositive())).toOpaque())
-
-      let closure = {
-        (b: Bool) -> () -> Void in
-        return {
-          () -> Void in
-          var c = b
-          while true
-          {
-            if c
-            {
-              if let t = CAtomicsUnmanagedLockAndLoad(a)
-              {
-                let u = Unmanaged<Thing>.fromOpaque(t).retain()
-                CAtomicsStore(a, t, .release)
-                let thing = u.takeRetainedValue()
-                XCTAssertNotEqual(thing.id, 0)
-              }
-              else
-              {
-                return
-              }
-            }
-            else
-            {
-              if let t = CAtomicsExchange(a, nil, .acqrel)
-              {
-                let u = Unmanaged<Thing>.fromOpaque(t).retain()
-                let thing = u.takeRetainedValue()
-                XCTAssertNotEqual(thing.id, 0)
-              }
-              else
-              {
-                return
-              }
-            }
-            c = !c
-          }
-        }
-      }
-
-      q.async(execute: closure(true))
-      q.async(execute: closure(false))
-      q.async(flags: .barrier) {
-#if swift(>=4.1)
-        a.deallocate()
-#else
-        a.deallocate(capacity: 1)
-#endif
-      }
-    }
-
-    q.sync(flags: .barrier, execute: {})
   }
 }

--- a/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsReferenceTests.swift
@@ -367,7 +367,7 @@ public class UnmanagedRaceTests: XCTestCase
             }
             else
             {
-              if let t = CAtomicsExchange(a, nil, .acquire)
+              if let t = CAtomicsExchange(a, nil, .acqrel)
               {
                 let u = Unmanaged<Thing>.fromOpaque(t).retain()
                 let thing = u.takeRetainedValue()

--- a/Tests/CAtomicsTests/XCTestManifests.swift
+++ b/Tests/CAtomicsTests/XCTestManifests.swift
@@ -62,8 +62,7 @@ extension UnmanagedRaceTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UnmanagedRaceTests = [
-        ("testRaceAtomickishUnmanaged", testRaceAtomickishUnmanaged),
-        ("testRaceLoadVersusDeinit", testRaceLoadVersusDeinit),
+        ("testRaceAtomicUnmanaged", testRaceAtomicUnmanaged),
     ]
 }
 
@@ -72,14 +71,7 @@ extension UnmanagedTests {
     //   `swift test --generate-linuxmain`
     // to regenerate.
     static let __allTests__UnmanagedTests = [
-        ("testDemonstrateWhyLockIsNecessary", testDemonstrateWhyLockIsNecessary),
-        ("testSpinLoad", testSpinLoad),
-        ("testSpinSwap", testSpinSwap),
-        ("testSpinTake", testSpinTake),
-        ("testStrongCASFailure", testStrongCASFailure),
-        ("testStrongCASSuccess", testStrongCASSuccess),
         ("testUnmanaged", testUnmanaged),
-        ("testWeakCasBlocked", testWeakCasBlocked),
     ]
 }
 

--- a/Tests/SwiftAtomicsTests/XCTestManifests.swift
+++ b/Tests/SwiftAtomicsTests/XCTestManifests.swift
@@ -54,7 +54,6 @@ extension ReferenceRaceTests {
     // to regenerate.
     static let __allTests__ReferenceRaceTests = [
         ("testRaceAtomicReference", testRaceAtomicReference),
-        ("testRaceLoadVersusDeinit", testRaceLoadVersusDeinit),
     ]
 }
 


### PR DESCRIPTION
- `load` required locking, and it failed once every many-many-million attempts (under contention), and that just made it unusable. There's been a lot of trying to fix it, but nothing has completely worked.
- it's much simpler now, and the other operations on `AtomicReference` are quite useful anyway.