### PR TITLE
Change long to intptr_t for LLP64 platforms

### DIFF
--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -293,14 +293,14 @@ CLANG_ATOMICS_POINTER_GENERATE(AtomicOptionalOpaquePointer, atomic_uintptr_t, st
           unionType tag_ptr; \
           struct { \
             pointerType nullability ptr; \
-            long tag; \
+            intptr_t tag; \
           }; \
         } swiftType;
 
 #define CLANG_ATOMICS_TAGGED_POINTER_CREATE(swiftType, pointerType, nullability) \
         static __inline__ __attribute__((__always_inline__)) \
         SWIFT_NAME(swiftType.init(_:tag:)) \
-        swiftType swiftType##Create(pointerType nullability p, long tag) \
+        swiftType swiftType##Create(pointerType nullability p, intptr_t tag) \
         { swiftType s; s.tag = tag; s.ptr = p; return s; }
 
 #define CLANG_ATOMICS_TAGGED_POINTER_INCREMENT(swiftType, pointerType, nullability) \


### PR DESCRIPTION
On Windows, `long` is imported as `Int32` rather than `Int`.
Use `intptr_t` to ensure that `tag` is imported as `Int`.