### PR TITLE
adjust CAS functions

### DIFF
--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -162,12 +162,10 @@ SWIFT_ENUM(CASType, closed)
         _Bool CAtomicsCompareAndExchange(swiftType *_Nonnull atomic, parameterType *_Nonnull current, parameterType future, \
                                          enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
-          assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
-          assert(orderSwap == __ATOMIC_RELEASE ? orderLoad == __ATOMIC_RELAXED : true); \
           if(type == __ATOMIC_CAS_TYPE_STRONG) \
-            return atomic_compare_exchange_strong_explicit(&(atomic->a), current, future, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeStrong(atomic, current, future, orderSwap, orderLoad); \
           else \
-            return atomic_compare_exchange_weak_explicit(&(atomic->a), current, future, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeWeak(atomic, current, future, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
         __attribute__((overloadable)) \
@@ -292,12 +290,10 @@ CLANG_ATOMICS_BOOL_GENERATE(AtomicBool, atomic_bool, _Bool, _Alignof(atomic_bool
                                          parameterType nullability* _Nonnull current, parameterType nullability future, \
                                          enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
-          assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
-          assert(orderSwap == __ATOMIC_RELEASE ? orderLoad == __ATOMIC_RELAXED : true); \
           if(type == __ATOMIC_CAS_TYPE_STRONG) \
-            return atomic_compare_exchange_strong_explicit(&(atomic->a), (uintptr_t*)current, (uintptr_t)future, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeStrong(atomic, current, future, orderSwap, orderLoad); \
           else \
-            return atomic_compare_exchange_weak_explicit(&(atomic->a), (uintptr_t*)current, (uintptr_t)future, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeWeak(atomic, current, future, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
         __attribute__((overloadable)) \
@@ -423,12 +419,10 @@ CLANG_ATOMICS_POINTER_GENERATE(AtomicOptionalOpaquePointer, atomic_uintptr_t, st
         _Bool CAtomicsCompareAndExchange(atomicType *_Nonnull atomic, structType *_Nonnull current, structType future, \
                                          enum CASType type, enum MemoryOrder orderSwap, enum LoadMemoryOrder orderLoad) \
         { \
-          assert((unsigned int)orderLoad <= (unsigned int)orderSwap); \
-          assert(orderSwap == __ATOMIC_RELEASE ? orderLoad == __ATOMIC_RELAXED : true); \
           if(type == __ATOMIC_CAS_TYPE_STRONG) \
-            return atomic_compare_exchange_strong_explicit(&(atomic->a), &(current->tag_ptr), future.tag_ptr, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeStrong(atomic, current, future, orderSwap, orderLoad); \
           else \
-            return atomic_compare_exchange_weak_explicit(&(atomic->a), &(current->tag_ptr), future.tag_ptr, orderSwap, orderLoad); \
+            return CAtomicsCompareAndExchangeWeak(atomic, current, future, orderSwap, orderLoad); \
         } \
         static __inline__ __attribute__((__always_inline__)) \
         __attribute__((overloadable)) \

--- a/Sources/CAtomics/include/CAtomics.h
+++ b/Sources/CAtomics/include/CAtomics.h
@@ -495,15 +495,21 @@ CLANG_ATOMICS_POINTER_LOAD(OpaqueUnmanagedHelper, const void*, _Nullable)
 
 static __inline__ __attribute__((__always_inline__)) \
 __attribute__((overloadable)) \
+_Bool CAtomicsCompareAndExchangeStrong(OpaqueUnmanagedHelper *_Nonnull atomic,
+                                       const void *_Nullable current, const void *_Nullable future,
+                                       enum MemoryOrder order)
+{
+  uintptr_t pointer = (uintptr_t) current;
+  return atomic_compare_exchange_strong_explicit(&(atomic->a), &pointer, (uintptr_t)future, order, memory_order_relaxed);
+}
+
+static __inline__ __attribute__((__always_inline__)) \
+__attribute__((overloadable)) \
 _Bool CAtomicsCompareAndExchange(OpaqueUnmanagedHelper *_Nonnull atomic,
                                  const void *_Nullable current, const void *_Nullable future,
                                  enum CASType type, enum MemoryOrder order)
 {
-  uintptr_t pointer = (uintptr_t) current;
-  if(type == __ATOMIC_CAS_TYPE_WEAK)
-    return atomic_compare_exchange_weak_explicit(&(atomic->a), &pointer, (uintptr_t)future, order, memory_order_relaxed);
-  else
-    return atomic_compare_exchange_strong_explicit(&(atomic->a), &pointer, (uintptr_t)future, order, memory_order_relaxed);
+  return CAtomicsCompareAndExchangeStrong(atomic, current, future, order);
 }
 
 #endif

--- a/Sources/SwiftAtomics/atomics-integer.swift
+++ b/Sources/SwiftAtomics/atomics-integer.swift
@@ -93,7 +93,7 @@ extension AtomicInt
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Int, future: Int,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -187,7 +187,7 @@ extension AtomicInt
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int, future: Int,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -288,7 +288,7 @@ extension AtomicUInt
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UInt, future: UInt,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -382,7 +382,7 @@ extension AtomicUInt
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt, future: UInt,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -483,7 +483,7 @@ extension AtomicInt8
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Int8, future: Int8,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -577,7 +577,7 @@ extension AtomicInt8
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int8, future: Int8,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -678,7 +678,7 @@ extension AtomicUInt8
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UInt8, future: UInt8,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -772,7 +772,7 @@ extension AtomicUInt8
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt8, future: UInt8,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -873,7 +873,7 @@ extension AtomicInt16
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Int16, future: Int16,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -967,7 +967,7 @@ extension AtomicInt16
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int16, future: Int16,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1068,7 +1068,7 @@ extension AtomicUInt16
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UInt16, future: UInt16,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1162,7 +1162,7 @@ extension AtomicUInt16
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt16, future: UInt16,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1263,7 +1263,7 @@ extension AtomicInt32
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Int32, future: Int32,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1357,7 +1357,7 @@ extension AtomicInt32
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int32, future: Int32,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1458,7 +1458,7 @@ extension AtomicUInt32
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UInt32, future: UInt32,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1552,7 +1552,7 @@ extension AtomicUInt32
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt32, future: UInt32,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1653,7 +1653,7 @@ extension AtomicInt64
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Int64, future: Int64,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1747,7 +1747,7 @@ extension AtomicInt64
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int64, future: Int64,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1848,7 +1848,7 @@ extension AtomicUInt64
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UInt64, future: UInt64,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1942,7 +1942,7 @@ extension AtomicUInt64
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt64, future: UInt64,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -2022,7 +2022,7 @@ extension AtomicBool
 
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout Bool, future: Bool,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -2095,7 +2095,7 @@ extension AtomicBool
 
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Bool, future: Bool,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {

--- a/Sources/SwiftAtomics/atomics-integer.swift
+++ b/Sources/SwiftAtomics/atomics-integer.swift
@@ -22,202 +22,188 @@ extension AtomicInt
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Int)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Int, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Int, future: Int,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Int, future: Int,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Int {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Int)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Int)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Int
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Int, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Int, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int, order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> Int
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Int, future: Int,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int, future: Int,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Int, future: Int,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Int, future: Int,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -231,202 +217,188 @@ extension AtomicUInt
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: UInt)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: UInt, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout UInt, future: UInt,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: UInt, future: UInt,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: UInt {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: UInt)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: UInt)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: UInt, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: UInt, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt, order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout UInt, future: UInt,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt, future: UInt,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: UInt, future: UInt,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: UInt, future: UInt,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -440,202 +412,188 @@ extension AtomicInt8
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Int8)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int8
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Int8, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int8
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Int8, future: Int8,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Int8, future: Int8,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Int8 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Int8)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Int8)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int8
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Int8
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Int8, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Int8, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int8, order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int8
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> Int8
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Int8, future: Int8,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int8, future: Int8,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Int8, future: Int8,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Int8, future: Int8,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -649,202 +607,188 @@ extension AtomicUInt8
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: UInt8)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt8
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: UInt8, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt8
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout UInt8, future: UInt8,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: UInt8, future: UInt8,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: UInt8 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: UInt8)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: UInt8)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt8
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt8
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: UInt8, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: UInt8, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt8, order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt8
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt8
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout UInt8, future: UInt8,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt8, future: UInt8,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: UInt8, future: UInt8,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: UInt8, future: UInt8,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -858,202 +802,188 @@ extension AtomicInt16
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Int16)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int16
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Int16, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int16
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Int16, future: Int16,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Int16, future: Int16,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Int16 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Int16)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Int16)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int16
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Int16
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Int16, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Int16, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int16, order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int16
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> Int16
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Int16, future: Int16,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int16, future: Int16,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Int16, future: Int16,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Int16, future: Int16,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -1067,202 +997,188 @@ extension AtomicUInt16
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: UInt16)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt16
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: UInt16, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt16
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout UInt16, future: UInt16,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: UInt16, future: UInt16,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: UInt16 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: UInt16)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: UInt16)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt16
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt16
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: UInt16, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: UInt16, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt16, order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt16
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt16
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout UInt16, future: UInt16,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt16, future: UInt16,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: UInt16, future: UInt16,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: UInt16, future: UInt16,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -1276,202 +1192,188 @@ extension AtomicInt32
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Int32)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int32
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Int32, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int32
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Int32, future: Int32,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Int32, future: Int32,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Int32 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Int32)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Int32)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int32
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Int32
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Int32, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Int32, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int32, order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int32
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> Int32
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Int32, future: Int32,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int32, future: Int32,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Int32, future: Int32,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Int32, future: Int32,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -1485,202 +1387,188 @@ extension AtomicUInt32
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: UInt32)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt32
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt32
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout UInt32, future: UInt32,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: UInt32, future: UInt32,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: UInt32 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: UInt32)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: UInt32)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt32
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt32
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: UInt32, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt32, order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt32
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt32
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout UInt32, future: UInt32,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt32, future: UInt32,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: UInt32, future: UInt32,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: UInt32, future: UInt32,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -1694,202 +1582,188 @@ extension AtomicInt64
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Int64)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int64
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Int64, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int64
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Int64, future: Int64,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Int64, future: Int64,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Int64 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Int64)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Int64)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Int64
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Int64
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Int64, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Int64, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: Int64, order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> Int64
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> Int64
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Int64, future: Int64,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Int64, future: Int64,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Int64, future: Int64,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Int64, future: Int64,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -1903,202 +1777,188 @@ extension AtomicUInt64
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: UInt64)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt64
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func add(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsAdd(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func subtract(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsSubtract(&self, delta, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseOr(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsBitwiseOr(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseXor(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsBitwiseXor(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func bitwiseAnd(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsBitwiseAnd(&self, bits, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsAdd(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt64
+  {
+    return CAtomicsSubtract(&self, 1, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout UInt64, future: UInt64,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: UInt64, future: UInt64,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: UInt64 {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: UInt64)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: UInt64)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt64
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> UInt64
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: UInt64, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func add(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsAdd(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func add(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsAdd(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func subtract(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsSubtract(&self, delta, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func subtract(_ delta: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsSubtract(&self, delta, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseOr(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsBitwiseOr(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseOr(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsBitwiseOr(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseXor(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsBitwiseXor(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseXor(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsBitwiseXor(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func bitwiseAnd(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsBitwiseAnd(&self, bits, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func bitwiseAnd(_ bits: UInt64, order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsBitwiseAnd(&self, bits, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func increment(order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsAdd(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func increment(order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsAdd(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt64
-  {
-    return CAtomicsSubtract(&self, 1, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func decrement(order: MemoryOrder = .acqrel) -> UInt64
   {
     return CAtomicsSubtract(&self, 1, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout UInt64, future: UInt64,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UInt64, future: UInt64,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: UInt64, future: UInt64,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: UInt64, future: UInt64,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }
@@ -2112,146 +1972,146 @@ extension AtomicBool
     @inlinable
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
+
+  @inlinable
+  public mutating func initialize(_ value: Bool)
+  {
+    CAtomicsInitialize(&self, value)
+  }
+
+
+  @inlinable
+  public mutating func load(order: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return CAtomicsLoad(&self, order)
+  }
+
+  @inlinable
+  public mutating func store(_ value: Bool, order: StoreMemoryOrder = .release)
+  {
+    CAtomicsStore(&self, value, order)
+  }
+
+
+  @inlinable
+  public mutating func swap(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
+  {
+    return CAtomicsExchange(&self, value, order)
+  }
+
+
+  @inlinable @discardableResult
+  public mutating func or(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
+  {
+    return CAtomicsOr(&self, value, order)
+  }
+
+
+  @inlinable @discardableResult
+  public mutating func xor(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
+  {
+    return CAtomicsXor(&self, value, order)
+  }
+
+
+  @inlinable @discardableResult
+  public mutating func and(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
+  {
+    return CAtomicsAnd(&self, value, order)
+  }
+
+  @inlinable @discardableResult
+  public mutating func loadCAS(current: inout Bool, future: Bool,
+                               type: CASType = .weak,
+                               orderSwap: MemoryOrder = .acqrel,
+                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
+  {
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
+  }
+
+  @inlinable @discardableResult
+  public mutating func CAS(current: Bool, future: Bool,
+                           type: CASType = .strong,
+                           order: MemoryOrder = .acqrel) -> Bool
+  {
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
+  }
 #else
   public var value: Bool {
     @inline(__always)
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func initialize(_ value: Bool)
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#else
   @inline(__always)
   public mutating func initialize(_ value: Bool)
   {
     CAtomicsInitialize(&self, value)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#else
+
   @inline(__always)
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Bool
   {
     return CAtomicsLoad(&self, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func store(_ value: Bool, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#else
   @inline(__always)
   public mutating func store(_ value: Bool, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
-  public mutating func swap(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#else
+
   @inline(__always)
   public mutating func swap(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
   {
     return CAtomicsExchange(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func or(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsOr(&self, value, order)
-  }
-#else
+
   @inline(__always) @discardableResult
   public mutating func or(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
   {
     return CAtomicsOr(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func xor(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsXor(&self, value, order)
-  }
-#else
+
   @inline(__always) @discardableResult
   public mutating func xor(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
   {
     return CAtomicsXor(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func and(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsAnd(&self, value, order)
-  }
-#else
+
   @inline(__always) @discardableResult
   public mutating func and(_ value: Bool, order: MemoryOrder = .acqrel) -> Bool
   {
     return CAtomicsAnd(&self, value, order)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func loadCAS(current: inout Bool, future: Bool,
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout Bool, future: Bool,
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
-  public mutating func CAS(current: Bool, future: Bool,
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#else
   @inline(__always) @discardableResult
   public mutating func CAS(current: Bool, future: Bool,
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
 #endif
 }

--- a/Sources/SwiftAtomics/atomics-integer.swift.gyb
+++ b/Sources/SwiftAtomics/atomics-integer.swift.gyb
@@ -84,7 +84,7 @@ extension ${AtomicType}
 % end # if IntType == 'Bool'
   ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout ${IntType}, future: ${IntType},
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {

--- a/Sources/SwiftAtomics/atomics-integer.swift.gyb
+++ b/Sources/SwiftAtomics/atomics-integer.swift.gyb
@@ -20,160 +20,89 @@ import CAtomics
 extension ${AtomicType}
 {
 #if swift(>=4.2)
+% for inlinable in ['@inlinable', '@inline(__always)']:
+% usableFromInline = '@usableFromInline' if inlinable == '@inlinable' else '@_versioned'
+% end = '#else' if inlinable == '@inlinable' else '#endif'
   public var value: ${IntType} {
-    @inlinable
+    ${inlinable}
     mutating get { return CAtomicsLoad(&self, .relaxed) }
   }
-#else
-  public var value: ${IntType} {
-    @inline(__always)
-    mutating get { return CAtomicsLoad(&self, .relaxed) }
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func initialize(_ value: ${IntType})
   {
     CAtomicsInitialize(&self, value)
   }
-#else
-  @inline(__always)
-  public mutating func initialize(_ value: ${IntType})
-  {
-    CAtomicsInitialize(&self, value)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+
+  ${inlinable}
   public mutating func load(order: LoadMemoryOrder = .acquire) -> ${IntType}
   {
     return CAtomicsLoad(&self, order)
   }
-#else
-  @inline(__always)
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> ${IntType}
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func store(_ value: ${IntType}, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, value, order)
   }
-#else
-  @inline(__always)
-  public mutating func store(_ value: ${IntType}, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, value, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+
+  ${inlinable}
   public mutating func swap(_ value: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
   {
     return CAtomicsExchange(&self, value, order)
   }
-#else
-  @inline(__always)
-  public mutating func swap(_ value: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
-  {
-    return CAtomicsExchange(&self, value, order)
-  }
-#endif
 
 % if IntType == 'Bool':
 % for (rmwMethod, rmwFunc, rmwParam) in [('or', 'Or', 'value'), ('xor', 'Xor', 'value'), ('and', 'And', 'value')]:
-#if swift(>=4.2)
-  @inlinable @discardableResult
+
+  ${inlinable} @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
   {
     return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
-  {
-    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
-  }
-#endif
 
 % end # for
 % else:
 % for (rmwMethod, rmwFunc, rmwParam) in [('add', 'Add', 'delta'), ('subtract', 'Subtract', 'delta'), ('bitwiseOr', 'BitwiseOr', 'bits'), ('bitwiseXor', 'BitwiseXor', 'bits'), ('bitwiseAnd', 'BitwiseAnd', 'bits')]:
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
   {
     return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func ${rmwMethod}(_ ${rmwParam}: ${IntType}, order: MemoryOrder = .acqrel) -> ${IntType}
-  {
-    return CAtomics${rmwFunc}(&self, ${rmwParam}, order)
-  }
-#endif
 
 % end # for
 % for (inc, op) in [('increment', 'Add'), ('decrement', 'Subtract')]:
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func ${inc}(order: MemoryOrder = .acqrel) -> ${IntType}
   {
     return CAtomics${op}(&self, 1, order)
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func ${inc}(order: MemoryOrder = .acqrel) -> ${IntType}
-  {
-    return CAtomics${op}(&self, 1, order)
-  }
-#endif
 
 % end # for
 % end # if IntType == 'Bool'
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout ${IntType}, future: ${IntType},
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func loadCAS(current: inout ${IntType}, future: ${IntType},
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func CAS(current: ${IntType}, future: ${IntType},
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func CAS(current: ${IntType}, future: ${IntType},
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#endif
+${end}
+% end # inlinable
 }
 % end # for AtomicType

--- a/Sources/SwiftAtomics/atomics-orderings.swift
+++ b/Sources/SwiftAtomics/atomics-orderings.swift
@@ -1,0 +1,39 @@
+//
+//  atomics-orderings.swift
+//  
+//
+//  Created by Guillaume Lessard on 4/4/20.
+//
+
+import CAtomics
+
+extension MemoryOrder
+{
+#if swift(>=4.2)
+  @usableFromInline
+  internal func asLoadOrdering() -> LoadMemoryOrder
+  {
+    switch self {
+    case .relaxed:    return .relaxed
+    case .acquire:    return .acquire
+    case .release:    return .relaxed
+    case .acqrel :    return .acquire
+    case .sequential: return .sequential
+    default: return LoadMemoryOrder(rawValue: rawValue)!
+    }
+  }
+#else
+  @_versioned
+  internal func asLoadOrdering() -> LoadMemoryOrder
+  {
+    switch self {
+    case .relaxed:    return .relaxed
+    case .acquire:    return .acquire
+    case .release:    return .relaxed
+    case .acqrel :    return .acquire
+    case .sequential: return .sequential
+    default: return LoadMemoryOrder(rawValue: rawValue)!
+    }
+  }
+#endif
+}

--- a/Sources/SwiftAtomics/atomics-pointer.swift
+++ b/Sources/SwiftAtomics/atomics-pointer.swift
@@ -60,7 +60,7 @@ public struct AtomicPointer<Pointee>
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafePointer<Pointee>,
                                future: UnsafePointer<Pointee>,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -110,7 +110,7 @@ public struct AtomicPointer<Pointee>
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafePointer<Pointee>,
                                future: UnsafePointer<Pointee>,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -181,7 +181,7 @@ public struct AtomicMutablePointer<Pointee>
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutablePointer<Pointee>,
                                future: UnsafeMutablePointer<Pointee>,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -231,7 +231,7 @@ public struct AtomicMutablePointer<Pointee>
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutablePointer<Pointee>,
                                future: UnsafeMutablePointer<Pointee>,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -307,7 +307,7 @@ public struct AtomicOptionalPointer<Pointee>
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafePointer<Pointee>?,
                                future: UnsafePointer<Pointee>?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -357,7 +357,7 @@ public struct AtomicOptionalPointer<Pointee>
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafePointer<Pointee>?,
                                future: UnsafePointer<Pointee>?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -433,7 +433,7 @@ public struct AtomicOptionalMutablePointer<Pointee>
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutablePointer<Pointee>?,
                                future: UnsafeMutablePointer<Pointee>?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -483,7 +483,7 @@ public struct AtomicOptionalMutablePointer<Pointee>
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutablePointer<Pointee>?,
                                future: UnsafeMutablePointer<Pointee>?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -546,7 +546,7 @@ extension AtomicRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeRawPointer,
                                future: UnsafeRawPointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -599,7 +599,7 @@ extension AtomicRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeRawPointer,
                                future: UnsafeRawPointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -659,7 +659,7 @@ extension AtomicOptionalRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeRawPointer?,
                                future: UnsafeRawPointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -712,7 +712,7 @@ extension AtomicOptionalRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeRawPointer?,
                                future: UnsafeRawPointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -772,7 +772,7 @@ extension AtomicMutableRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutableRawPointer,
                                future: UnsafeMutableRawPointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -825,7 +825,7 @@ extension AtomicMutableRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutableRawPointer,
                                future: UnsafeMutableRawPointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -885,7 +885,7 @@ extension AtomicOptionalMutableRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutableRawPointer?,
                                future: UnsafeMutableRawPointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -938,7 +938,7 @@ extension AtomicOptionalMutableRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout UnsafeMutableRawPointer?,
                                future: UnsafeMutableRawPointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -998,7 +998,7 @@ extension AtomicOpaquePointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout OpaquePointer,
                                future: OpaquePointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1051,7 +1051,7 @@ extension AtomicOpaquePointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout OpaquePointer,
                                future: OpaquePointer,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1111,7 +1111,7 @@ extension AtomicOptionalOpaquePointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout OpaquePointer?,
                                future: OpaquePointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1164,7 +1164,7 @@ extension AtomicOptionalOpaquePointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout OpaquePointer?,
                                future: OpaquePointer?,
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1232,7 +1232,7 @@ extension AtomicTaggedRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeRawPointer, tag: Int),
                                future: (pointer: UnsafeRawPointer, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1293,7 +1293,7 @@ extension AtomicTaggedRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeRawPointer, tag: Int),
                                future: (pointer: UnsafeRawPointer, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1366,7 +1366,7 @@ extension AtomicTaggedOptionalRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeRawPointer?, tag: Int),
                                future: (pointer: UnsafeRawPointer?, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1427,7 +1427,7 @@ extension AtomicTaggedOptionalRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeRawPointer?, tag: Int),
                                future: (pointer: UnsafeRawPointer?, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1500,7 +1500,7 @@ extension AtomicTaggedMutableRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeMutableRawPointer, tag: Int),
                                future: (pointer: UnsafeMutableRawPointer, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1561,7 +1561,7 @@ extension AtomicTaggedMutableRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeMutableRawPointer, tag: Int),
                                future: (pointer: UnsafeMutableRawPointer, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1634,7 +1634,7 @@ extension AtomicTaggedOptionalMutableRawPointer
   @inlinable @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeMutableRawPointer?, tag: Int),
                                future: (pointer: UnsafeMutableRawPointer?, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -1695,7 +1695,7 @@ extension AtomicTaggedOptionalMutableRawPointer
   @inline(__always) @discardableResult
   public mutating func loadCAS(current: inout (pointer: UnsafeMutableRawPointer?, tag: Int),
                                future: (pointer: UnsafeMutableRawPointer?, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {

--- a/Sources/SwiftAtomics/atomics-pointer.swift.gyb
+++ b/Sources/SwiftAtomics/atomics-pointer.swift.gyb
@@ -20,10 +20,12 @@ import CAtomics
 public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
 {
 #if swift(>=4.2)
-  @usableFromInline var ptr = Atomic${Nullable}${Mutable}RawPointer()
-#else
-  @_versioned var ptr = Atomic${Nullable}${Mutable}RawPointer()
-#endif
+% for inlinable in ['@inlinable', '@inline(__always)']:
+% usableFromInline = '@usableFromInline' if inlinable == '@inlinable' else '@_versioned'
+% end = '#else' if inlinable == '@inlinable' else '#endif'
+  ${usableFromInline} var ptr = Atomic${Nullable}${Mutable}RawPointer()
+${end}
+% end # inlinable
 
 % if Nullable == 'Optional':
   public init()
@@ -43,65 +45,35 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
   }
 
 #if swift(>=4.2)
+% for inlinable in ['@inlinable', '@inline(__always)']:
+% usableFromInline = '@usableFromInline' if inlinable == '@inlinable' else '@_versioned'
+% end = '#else' if inlinable == '@inlinable' else '#endif'
   public var pointer: Unsafe${Mutable}${Pointer} {
-    @inlinable
+    ${inlinable}
     mutating get {
       return CAtomicsLoad(&ptr, .acquire)${optional}.assumingMemoryBound(to: Pointee.self)
     }
   }
-#else
-  public var pointer: Unsafe${Mutable}${Pointer} {
-    @inline(__always)
-    mutating get {
-      return CAtomicsLoad(&ptr, .acquire)${optional}.assumingMemoryBound(to: Pointee.self)
-    }
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func load(order: LoadMemoryOrder = .acquire) -> Unsafe${Mutable}${Pointer}
   {
     return CAtomicsLoad(&ptr, order)${optional}.assumingMemoryBound(to: Pointee.self)
   }
-#else
-  @inline(__always)
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> Unsafe${Mutable}${Pointer}
-  {
-    return CAtomicsLoad(&ptr, order)${optional}.assumingMemoryBound(to: Pointee.self)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func store(_ pointer: Unsafe${Mutable}${Pointer}, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&ptr, pointer, order)
   }
-#else
-  @inline(__always)
-  public mutating func store(_ pointer: Unsafe${Mutable}${Pointer}, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&ptr, pointer, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func swap(_ pointer: Unsafe${Mutable}${Pointer}, order: MemoryOrder = .acqrel) -> Unsafe${Mutable}${Pointer}
   {
     return CAtomicsExchange(&ptr, pointer, order)${optional}.assumingMemoryBound(to: Pointee.self)
   }
-#else
-  @inline(__always)
-  public mutating func swap(_ pointer: Unsafe${Mutable}${Pointer}, order: MemoryOrder = .acqrel) -> Unsafe${Mutable}${Pointer}
-  {
-    return CAtomicsExchange(&ptr, pointer, order)${optional}.assumingMemoryBound(to: Pointee.self)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout Unsafe${Mutable}${Pointer},
                                future: Unsafe${Mutable}${Pointer},
                                type: CASType = .weak,
@@ -109,42 +81,24 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
     var c = Unsafe${Mutable}RawPointer(current)
-    let s = CAtomicsCompareAndExchange(&ptr, &c, future, type, orderSwap, orderLoad)
+    let s = (type == .weak)
+            ? CAtomicsCompareAndExchangeWeak(&ptr, &c, future, orderSwap, orderLoad)
+            : CAtomicsCompareAndExchangeStrong(&ptr, &c, future, orderSwap, orderLoad)
     current = c${optional}.assumingMemoryBound(to: Pointee.self)
     return s
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func loadCAS(current: inout Unsafe${Mutable}${Pointer},
-                               future: Unsafe${Mutable}${Pointer},
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    var c = Unsafe${Mutable}RawPointer(current)
-    let s = CAtomicsCompareAndExchange(&ptr, &c, future, type, orderSwap, orderLoad)
-    current = c${optional}.assumingMemoryBound(to: Pointee.self)
-    return s
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func CAS(current: Unsafe${Mutable}${Pointer}, future: Unsafe${Mutable}${Pointer},
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&ptr, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func CAS(current: Unsafe${Mutable}${Pointer}, future: Unsafe${Mutable}${Pointer},
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&ptr, current, future, type, order)
-  }
-#endif
+${end}
+% end # inlinable
 }
 % end
 % end
@@ -158,116 +112,63 @@ public struct Atomic${Nullable}${Mutable}Pointer<Pointee>
 extension Atomic${optional}${type}Pointer
 {
 #if swift(>=4.2)
+% for inlinable in ['@inlinable', '@inline(__always)']:
+% usableFromInline = '@usableFromInline' if inlinable == '@inlinable' else '@_versioned'
+% end = '#else' if inlinable == '@inlinable' else '#endif'
   public var pointer: ${prefix}${type}Pointer${opt} {
-    @inlinable
+    ${inlinable}
     mutating get {
       return CAtomicsLoad(&self, .acquire)
     }
   }
-#else
-  public var pointer: ${prefix}${type}Pointer${opt} {
-    @inline(__always)
-    mutating get {
-      return CAtomicsLoad(&self, .acquire)
-    }
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func initialize(_ pointer: ${prefix}${type}Pointer${opt})
   {
     CAtomicsInitialize(&self, pointer)
   }
-#else
-  @inline(__always)
-  public mutating func initialize(_ pointer: ${prefix}${type}Pointer${opt})
-  {
-    CAtomicsInitialize(&self, pointer)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func load(order: LoadMemoryOrder = .acquire) -> ${prefix}${type}Pointer${opt}
   {
     return CAtomicsLoad(&self, order)
   }
-#else
-  @inline(__always)
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> ${prefix}${type}Pointer${opt}
-  {
-    return CAtomicsLoad(&self, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func store(_ pointer: ${prefix}${type}Pointer${opt}, order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, pointer, order)
   }
-#else
-  @inline(__always)
-  public mutating func store(_ pointer: ${prefix}${type}Pointer${opt}, order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, pointer, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func swap(_ pointer: ${prefix}${type}Pointer${opt}, order: MemoryOrder = .acqrel) -> ${prefix}${type}Pointer${opt}
   {
     return CAtomicsExchange(&self, pointer, order)
   }
-#else
-  @inline(__always)
-  public mutating func swap(_ pointer: ${prefix}${type}Pointer${opt}, order: MemoryOrder = .acqrel) -> ${prefix}${type}Pointer${opt}
-  {
-    return CAtomicsExchange(&self, pointer, order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout ${prefix}${type}Pointer${opt},
                                future: ${prefix}${type}Pointer${opt},
                                type: CASType = .weak,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
+    return type == .weak
+    ? CAtomicsCompareAndExchangeWeak(&self, &current, future, orderSwap, orderLoad)
+    : CAtomicsCompareAndExchangeStrong(&self, &current, future, orderSwap, orderLoad)
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func loadCAS(current: inout ${prefix}${type}Pointer${opt},
-                               future: ${prefix}${type}Pointer${opt},
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, &current, future, type, orderSwap, orderLoad)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func CAS(current: ${prefix}${type}Pointer${opt}, future: ${prefix}${type}Pointer${opt},
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func CAS(current: ${prefix}${type}Pointer${opt}, future: ${prefix}${type}Pointer${opt},
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    return CAtomicsCompareAndExchange(&self, current, future, type, order)
-  }
-#endif
+${end}
+% end # inlinable
 }
 % end
 % end

--- a/Sources/SwiftAtomics/atomics-pointer.swift.gyb
+++ b/Sources/SwiftAtomics/atomics-pointer.swift.gyb
@@ -186,85 +186,44 @@ extension AtomicTagged${optional}${type}Pointer
   }
 
 #if swift(>=4.2)
+% for inlinable in ['@inlinable', '@inline(__always)']:
+% usableFromInline = '@usableFromInline' if inlinable == '@inlinable' else '@_versioned'
+% end = '#else' if inlinable == '@inlinable' else '#endif'
   public var value: (pointer: Unsafe${type}Pointer${opt}, tag: Int) {
-    @inlinable
+    ${inlinable}
     mutating get {
       let t = CAtomicsLoad(&self, .acquire)
       return (t.ptr, t.tag)
     }
   }
-#else
-  public var value: (pointer: Unsafe${type}Pointer${opt}, tag: Int) {
-    @inline(__always)
-    mutating get {
-      let t = CAtomicsLoad(&self, .acquire)
-      return (t.ptr, t.tag)
-    }
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func initialize(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int))
   {
     CAtomicsInitialize(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag))
   }
-#else
-  @inline(__always)
-  public mutating func initialize(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int))
-  {
-    CAtomicsInitialize(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag))
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func load(order: LoadMemoryOrder = .acquire) -> (pointer: Unsafe${type}Pointer${opt}, tag: Int)
   {
     let t = CAtomicsLoad(&self, order)
     return (t.ptr, t.tag)
   }
-#else
-  @inline(__always)
-  public mutating func load(order: LoadMemoryOrder = .acquire) -> (pointer: Unsafe${type}Pointer${opt}, tag: Int)
-  {
-    let t = CAtomicsLoad(&self, order)
-    return (t.ptr, t.tag)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func store(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int), order: StoreMemoryOrder = .release)
   {
     CAtomicsStore(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag), order)
   }
-#else
-  @inline(__always)
-  public mutating func store(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int), order: StoreMemoryOrder = .release)
-  {
-    CAtomicsStore(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag), order)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable
+  ${inlinable}
   public mutating func swap(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int), order: MemoryOrder = .acqrel) -> (pointer: Unsafe${type}Pointer${opt}, tag: Int)
   {
     let t = CAtomicsExchange(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag), order)
     return (t.ptr, t.tag)
   }
-#else
-  @inline(__always)
-  public mutating func swap(_ p: (pointer: Unsafe${type}Pointer${opt}, tag: Int), order: MemoryOrder = .acqrel) -> (pointer: Unsafe${type}Pointer${opt}, tag: Int)
-  {
-    let t = CAtomicsExchange(&self, Tagged${optional}${type}Pointer(p.pointer, tag: p.tag), order)
-    return (t.ptr, t.tag)
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout (pointer: Unsafe${type}Pointer${opt}, tag: Int),
                                future: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
                                type: CASType = .weak,
@@ -273,49 +232,25 @@ extension AtomicTagged${optional}${type}Pointer
   {
     var c = Tagged${optional}${type}Pointer(current.0, tag: current.1)
     let f = Tagged${optional}${type}Pointer(future.0, tag: future.1)
-    let s = CAtomicsCompareAndExchange(&self, &c, f, type, orderSwap, orderLoad)
+    let s = (type == .weak)
+            ? CAtomicsCompareAndExchangeWeak(&self, &c, f, orderSwap, orderLoad)
+            : CAtomicsCompareAndExchangeStrong(&self, &c, f, orderSwap, orderLoad)
     current = (c.ptr, c.tag)
     return s
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func loadCAS(current: inout (pointer: Unsafe${type}Pointer${opt}, tag: Int),
-                               future: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
-                               type: CASType = .weak,
-                               orderSwap: MemoryOrder = .acqrel,
-                               orderLoad: LoadMemoryOrder = .acquire) -> Bool
-  {
-    var c = Tagged${optional}${type}Pointer(current.0, tag: current.1)
-    let f = Tagged${optional}${type}Pointer(future.0, tag: future.1)
-    let s = CAtomicsCompareAndExchange(&self, &c, f, type, orderSwap, orderLoad)
-    current = (c.ptr, c.tag)
-    return s
-  }
-#endif
 
-#if swift(>=4.2)
-  @inlinable @discardableResult
+  ${inlinable} @discardableResult
   public mutating func CAS(current: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
                            future: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
                            type: CASType = .strong,
                            order: MemoryOrder = .acqrel) -> Bool
   {
-    let c = Tagged${optional}${type}Pointer(current.0, tag: current.1)
-    let f = Tagged${optional}${type}Pointer(future.0, tag: future.1)
-    return CAtomicsCompareAndExchange(&self, c, f, type, order)
+    var current = current
+    return loadCAS(current: &current, future: future, type: type,
+                   orderSwap: order, orderLoad: order.asLoadOrdering())
   }
-#else
-  @inline(__always) @discardableResult
-  public mutating func CAS(current: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
-                           future: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
-                           type: CASType = .strong,
-                           order: MemoryOrder = .acqrel) -> Bool
-  {
-    let c = Tagged${optional}${type}Pointer(current.0, tag: current.1)
-    let f = Tagged${optional}${type}Pointer(future.0, tag: future.1)
-    return CAtomicsCompareAndExchange(&self, c, f, type, order)
-  }
-#endif
+${end}
+% end # inlinable
 }
 
 % end

--- a/Sources/SwiftAtomics/atomics-pointer.swift.gyb
+++ b/Sources/SwiftAtomics/atomics-pointer.swift.gyb
@@ -76,7 +76,7 @@ ${end}
   ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout Unsafe${Mutable}${Pointer},
                                future: Unsafe${Mutable}${Pointer},
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -149,7 +149,7 @@ extension Atomic${optional}${type}Pointer
   ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout ${prefix}${type}Pointer${opt},
                                future: ${prefix}${type}Pointer${opt},
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {
@@ -226,7 +226,7 @@ extension AtomicTagged${optional}${type}Pointer
   ${inlinable} @discardableResult
   public mutating func loadCAS(current: inout (pointer: Unsafe${type}Pointer${opt}, tag: Int),
                                future: (pointer: Unsafe${type}Pointer${opt}, tag: Int),
-                               type: CASType = .weak,
+                               type: CASType = .strong,
                                orderSwap: MemoryOrder = .acqrel,
                                orderLoad: LoadMemoryOrder = .acquire) -> Bool
   {

--- a/Sources/SwiftAtomics/atomics-reference.swift
+++ b/Sources/SwiftAtomics/atomics-reference.swift
@@ -148,7 +148,7 @@ extension AtomicReference
     let c = current.map(Unmanaged.passUnretained)
     let f = future.map(Unmanaged.passRetained)
 
-    if CAtomicsCompareAndExchange(&ptr, c?.toOpaque(), f?.toOpaque(), .strong, order)
+    if CAtomicsCompareAndExchangeStrong(&ptr, c?.toOpaque(), f?.toOpaque(), order)
     {
       c?.release()
       return true
@@ -165,7 +165,7 @@ extension AtomicReference
     let c = current.map(Unmanaged.passUnretained)
     let f = future.map(Unmanaged.passRetained)
 
-    if CAtomicsCompareAndExchange(&ptr, c?.toOpaque(), f?.toOpaque(), .strong, order)
+    if CAtomicsCompareAndExchangeStrong(&ptr, c?.toOpaque(), f?.toOpaque(), order)
     {
       c?.release()
       return true

--- a/Tests/CAtomicsTests/CAtomicsTests.swift
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift
@@ -61,12 +61,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -120,12 +120,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -179,12 +179,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -238,12 +238,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -297,12 +297,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -356,12 +356,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -415,12 +415,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -474,12 +474,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -533,12 +533,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -592,12 +592,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -642,12 +642,13 @@ public class CAtomicsBasicTests: XCTestCase
 
     var current = true
     XCTAssertEqual(CAtomicsLoad(&b, .relaxed), current)
-    CAtomicsCompareAndExchange(&b, &current, false, .strong, .relaxed, .relaxed)
+    CAtomicsCompareAndExchangeStrong(&b, &current, false, .relaxed, .relaxed)
     XCTAssertEqual(CAtomicsLoad(&b, .relaxed), false)
 
-    XCTAssertEqual(CAtomicsCompareAndExchange(&b, false, true, .strong, .relaxed), true)
-    while !CAtomicsCompareAndExchange(&b, &current, false, .weak, .relaxed, .relaxed) {}
-    while !CAtomicsCompareAndExchange(&b, !current, true, .weak, .relaxed) {}
+    current = false
+    XCTAssertEqual(CAtomicsCompareAndExchangeStrong(&b, &current, true, .relaxed, .relaxed), true)
+    while !CAtomicsCompareAndExchangeWeak(&b, &current, false, .relaxed, .relaxed) {}
+    while !CAtomicsCompareAndExchangeWeak(&b, &current, true, .relaxed, .relaxed) {}
   }
 }
 
@@ -674,14 +675,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -707,14 +710,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -740,14 +745,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -773,14 +780,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -806,14 +815,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -839,14 +850,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -947,14 +960,15 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -1011,14 +1025,15 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -1075,14 +1090,15 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -1139,14 +1155,15 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }

--- a/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
+++ b/Tests/CAtomicsTests/CAtomicsTests.swift.gyb
@@ -64,12 +64,12 @@ public class CAtomicsBasicTests: XCTestCase
 
     j = r1
     CAtomicsStore(&i, r1, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&i, &j, r2, .strong, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&i, &j, r2, .relaxed, .relaxed))
     XCTAssertEqual(r2, CAtomicsLoad(&i, .relaxed))
 
     j = r2
     CAtomicsStore(&i, r1, .relaxed)
-    while(!CAtomicsCompareAndExchange(&i, &j, r3, .weak, .relaxed, .relaxed)) {}
+    while(!CAtomicsCompareAndExchangeWeak(&i, &j, r3, .relaxed, .relaxed)) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&i, .relaxed))
   }
@@ -115,12 +115,13 @@ public class CAtomicsBasicTests: XCTestCase
 
     var current = true
     XCTAssertEqual(CAtomicsLoad(&b, .relaxed), current)
-    CAtomicsCompareAndExchange(&b, &current, false, .strong, .relaxed, .relaxed)
+    CAtomicsCompareAndExchangeStrong(&b, &current, false, .relaxed, .relaxed)
     XCTAssertEqual(CAtomicsLoad(&b, .relaxed), false)
 
-    XCTAssertEqual(CAtomicsCompareAndExchange(&b, false, true, .strong, .relaxed), true)
-    while !CAtomicsCompareAndExchange(&b, &current, false, .weak, .relaxed, .relaxed) {}
-    while !CAtomicsCompareAndExchange(&b, !current, true, .weak, .relaxed) {}
+    current = false
+    XCTAssertEqual(CAtomicsCompareAndExchangeStrong(&b, &current, true, .relaxed, .relaxed), true)
+    while !CAtomicsCompareAndExchangeWeak(&b, &current, false, .relaxed, .relaxed) {}
+    while !CAtomicsCompareAndExchangeWeak(&b, &current, true, .relaxed, .relaxed) {}
   }
 }
 
@@ -153,14 +154,16 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    j = r3
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }
@@ -264,14 +267,15 @@ extension CAtomicsBasicTests
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r2, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r3, .strong, .relaxed))
+    j = r2
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r3, .relaxed, .relaxed))
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
 
-    XCTAssertFalse(CAtomicsCompareAndExchange(&p, j, r2, .strong, .relaxed))
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r3, r2, .strong, .relaxed))
+    XCTAssertFalse(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r2, .relaxed, .relaxed))
     j = CAtomicsLoad(&p, .relaxed)
-    XCTAssertTrue(CAtomicsCompareAndExchange(&p, r2, r1, .strong, .relaxed))
-    while !CAtomicsCompareAndExchange(&p, &j, r3, .weak, .relaxed, .relaxed) {}
+    XCTAssertTrue(CAtomicsCompareAndExchangeStrong(&p, &j, r1, .relaxed, .relaxed))
+    while !CAtomicsCompareAndExchangeWeak(&p, &j, r3, .relaxed, .relaxed) {}
     XCTAssertEqual(r1, j)
     XCTAssertEqual(r3, CAtomicsLoad(&p, .relaxed))
   }


### PR DESCRIPTION
- encode Strong/Weak into the function names of `CAtomics`
- restrict branching on Strong/Weak CAS to `SwiftAtomics`
- make all CAS functions of `SwiftAtomics` default to `.strong`
- the old CAS functions with a `CASType` parameter still exist, but it would be nicer if they didn't.
